### PR TITLE
Fix Android asset name for GH release upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
         uses: ./.github/actions/upload
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          file-name: powersync-android.zip
+          file-name: powersync_android.zip
           tag: ${{ needs.draft_release.outputs.tag }}
 
   publish_ios_pod_and_spm_package:


### PR DESCRIPTION
The Android publishing step first uploads the built Android library to Maven Central and then also attaches it to the GH release (that asset is not used by us today, but it may be useful for inspection).

The upload to maven central worked, but the second step uses a wrong file name. For the `0.4.2` release, I've manually attached the asset. This PR fixes the file name for subsequent releases.