### PR TITLE
Create release on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,8 @@
 name: release
 on:
-  workflow_dispatch:
-    inputs:
-      publish:
-        type: boolean
-        required: false
-        default: false
-        description: Set to true to publish artifacts to external targets such as Maven Central
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
 jobs:
   draft_release:
     if: github.event_name == 'workflow_dispatch'
@@ -63,7 +59,6 @@ jobs:
           name: android-library
 
       - name: Publish to Maven Central
-        if: ${{ inputs.publish }}
         run: |
           curl --request POST \
             --header 'Authorization: Bearer ${{ secrets.CENTRAL_AUTH }}' \
@@ -313,3 +308,49 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           file-name: libpowersync-wasm.a
           tag: ${{ needs.draft_release.outputs.tag }}
+
+  create_sdk_issue:
+    name: "Create issue for SDK updates"
+    permissions:
+      issues: write
+    runs-on: macos-latest
+    needs:
+      - draft_release
+      - publish_android
+      - publish_ios_pod_and_spm_package
+      - publish_linux_x86_64
+      - publish_linux_aarch64
+      - publish_windows_x64
+      - publish_macOS_aarch64
+      - publish_macOS_x64
+      - publish_wasm
+    steps:
+      - name: Create issue
+        run: |
+          gh issue create \
+            --title "$TITLE" \
+            --assignee "$ASSIGNEES" \
+            --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}          
+          TITLE: "Release checklist: ${{ needs.draft_release.outputs.tag }}"
+          ASSIGNES: ${{ github.event.push.sender }}
+          BODY: |
+            This is a checklist to track the release of ${{ needs.draft_release.outputs.tag }}.
+            
+            Core build (this repo):
+            * [x] GitHub Release
+            * [ ] Android aar released on Maven Central
+            * [ ] Cocoapod released
+
+            SQLite + powersync bundles:
+            * [ ] react-native-quick-sqlite: 
+            * [ ] wa-sqlite build: 
+            * [ ] sql.js dev adapter: 
+
+            User-facing SDK updates:
+            * [ ] powersync.dart:
+            * [ ] powersync-js:
+            * [ ] kotlin:
+            * [ ] swift:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,6 +1,6 @@
 # Preparing Release
 
-Bump the version number in these places:
+First, bump the version number in these places:
 
 1. Cargo.toml
 2. powersync-sqlite-core.podspec.
@@ -9,29 +9,29 @@ Bump the version number in these places:
 5. tool/build_xcframework.sh - `VERSION` variable.
 6. `cargo build` to update Cargo.lock
 
-Create a tag:
+Next, open a PR with these changes and wait for it to get approved and merged.
+
+# Perform Release
+
+Create a tag, which will trigger a release workflow when pushed:
 
 ```sh
 git tag -am v1.2.3 v1.2.3
 git push --tags
 ```
 
-# Perform Release
-
-Build:
-
-```
-gh workflow run release --ref v1.2.3 -f publish=true
-```
-
-The above does the following:
+The publishing workflow does the following:
 
 1. Create a draft GitHub release.
 2. Build the xcframework for iOS and macOS, and upload to GitHub (attached to the above release).
 3. Build and publish an Android aar to Sonatype. Afterwards, you can monitor the status of the publishing step [here](https://central.sonatype.com/publishing/deployments).
 
-Publish the cocoapod:
+The cocoapod needs to be published manually:
 
 ```sh
 pod trunk push powersync-sqlite-core.podspec
 ```
+
+# Updating SDKs
+
+The release workflow will create an issue with a list of items to update the individual SDKs and intermediate packages.


### PR DESCRIPTION
This replaces the manual workflow invocation with a trigger when `vx.y.z` tags are pushed to the repository, which is the same trigger we use for most of our SDKs.

I've also added a step to auto-create the release checklist.