### PR TITLE
Restore has_synced on iteration start

### DIFF
--- a/crates/core/src/sync/streaming_sync.rs
+++ b/crates/core/src/sync/streaming_sync.rs
@@ -577,8 +577,11 @@ impl StreamingSyncIteration {
             ));
         };
 
-        self.status
-            .update(|s| s.start_connecting(), &mut event.instructions);
+        let sync_state = self.adapter.collect_sync_state()?;
+        self.status.update(
+            move |s| s.start_connecting(sync_state),
+            &mut event.instructions,
+        );
 
         let requests = self.adapter.collect_bucket_requests()?;
         let local_bucket_names: Vec<String> = requests.iter().map(|s| s.name.clone()).collect();

--- a/crates/core/src/sync/sync_status.rs
+++ b/crates/core/src/sync/sync_status.rs
@@ -46,10 +46,12 @@ impl DownloadSyncStatus {
         self.downloading = None;
     }
 
-    pub fn start_connecting(&mut self) {
+    pub fn start_connecting(&mut self, status: Vec<SyncPriorityStatus>) {
         self.connected = false;
         self.downloading = None;
         self.connecting = true;
+        self.priority_status = status;
+        self.debug_assert_priority_status_is_sorted();
     }
 
     pub fn mark_connected(&mut self) {
@@ -161,9 +163,9 @@ pub struct Timestamp(pub i64);
 
 #[derive(Serialize, Hash)]
 pub struct SyncPriorityStatus {
-    priority: BucketPriority,
-    last_synced_at: Option<Timestamp>,
-    has_synced: Option<bool>,
+    pub priority: BucketPriority,
+    pub last_synced_at: Option<Timestamp>,
+    pub has_synced: Option<bool>,
 }
 
 /// Per-bucket download progress information.

--- a/dart/test/sync_test.dart
+++ b/dart/test/sync_test.dart
@@ -301,6 +301,46 @@ void _syncTests<T>({
     }
   });
 
+  syncTest('remembers sync state', (controller) {
+    invokeControl('start', null);
+
+    pushCheckpoint(buckets: priorityBuckets);
+    pushCheckpointComplete();
+
+    controller.elapse(Duration(minutes: 10));
+    pushCheckpoint(buckets: priorityBuckets);
+    pushCheckpointComplete(priority: 2);
+    invokeControl('stop', null);
+
+    final instructions = invokeControl('start', null);
+    expect(
+      instructions,
+      contains(
+        containsPair(
+          'UpdateSyncStatus',
+          containsPair(
+            'status',
+            containsPair(
+              'priority_status',
+              [
+                {
+                  'priority': 2,
+                  'last_synced_at': 1740823800,
+                  'has_synced': true
+                },
+                {
+                  'priority': 2147483647,
+                  'last_synced_at': 1740823200,
+                  'has_synced': true
+                },
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  });
+
   test('clearing database clears sync status', () {
     invokeControl('start', null);
     pushCheckpoint(buckets: priorityBuckets);


### PR DESCRIPTION
Currently, when a sync iteration is started (via the `start` `powersync_control` invocation), we return an instruction to initialize the sync status indicating that the client is connecting and an empty `priority_status` array.

Because that array is empty, `hasSynced` and `lastSyncedAt` entries in the sync status will be reset for all priorities in this case. This is not the correct behavior, we should use remembered per-priority sync state instead.
This is e.g. noticable in the demos for the Kotlin SDK, where disconnecting causes the "busy with sync" screen to show up because the status doesn't include the necessary entries when connecting fails.