### PR TITLE
Prepare 0.4.5 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powersync_core"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "bytes",
  "const_format",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "powersync_core",
  "sqlite_nostd",
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "cc",
  "powersync_core",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_static"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "powersync_core",
  "sqlite_nostd",
@@ -516,7 +516,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sqlite3"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 inherits = "wasm"
 
 [workspace.package]
-version = "0.4.4"
+version = "0.4.5"
 edition = "2024"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "com.powersync"
-version = "0.4.4"
+version = "0.4.5"
 description = "PowerSync Core SQLite Extension"
 
 val localRepo = uri("build/repository/")

--- a/android/src/prefab/prefab.json
+++ b/android/src/prefab/prefab.json
@@ -2,5 +2,5 @@
   "name": "powersync_sqlite_core",
   "schema_version": 2,
   "dependencies": [],
-  "version": "0.4.4"
+  "version": "0.4.5"
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,7 +1,5 @@
 #![no_std]
-#![allow(internal_features)]
 #![feature(btree_set_entry)]
-#![feature(core_intrinsics)]
 #![feature(assert_matches)]
 #![feature(strict_overflow_ops)]
 #![feature(vec_into_raw_parts)]

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.4.4'
+  s.version          = '0.4.5'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -25,7 +25,7 @@ TARGETS=(
   aarch64-apple-tvos-sim
   x86_64-apple-tvos
 )
-VERSION=0.4.4
+VERSION=0.4.5
 
 function generatePlist() {
   min_os_version=0


### PR DESCRIPTION
This prepares the release of version 0.4.5. Noteworthy changes include:

- Refactoring the CI pipeline to re-use more logic between the release and test runs (let's see if it works 🤞)
- A utility function replacing update hooks in drivers that don't support them.
- Sync streams!

I've also disabled an unused feature gate (there is no panic handler in `core`, so it doesn't need access to `core::intrinsics::abort()`).

I've considered making this a 0.5.0, but streams are supposed to be backwards-compatible (and unit tests with unchanged JS and Kotlin SDKs still work).