### PR TITLE
Prepare 0.4.7 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powersync_core"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "bytes",
  "const_format",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "powersync_core",
  "sqlite_nostd",
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "cc",
  "powersync_core",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_static"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "powersync_core",
  "sqlite_nostd",
@@ -516,7 +516,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sqlite3"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 inherits = "wasm"
 
 [workspace.package]
-version = "0.4.6"
+version = "0.4.7"
 edition = "2024"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.powersync"
-version = "0.4.6"
+version = "0.4.7"
 description = "PowerSync Core SQLite Extension"
 
 val localRepo = uri("build/repository/")

--- a/android/src/prefab/prefab.json
+++ b/android/src/prefab/prefab.json
@@ -2,5 +2,5 @@
   "name": "powersync_sqlite_core",
   "schema_version": 2,
   "dependencies": [],
-  "version": "0.4.6"
+  "version": "0.4.7"
 }

--- a/crates/static/src/lib.rs
+++ b/crates/static/src/lib.rs
@@ -24,8 +24,3 @@ static ALLOCATOR: SQLite3Allocator = SQLite3Allocator {};
 fn panic(_info: &core::panic::PanicInfo) -> ! {
     core::intrinsics::abort()
 }
-
-#[cfg(not(target_family = "wasm"))]
-#[cfg(not(test))]
-#[lang = "eh_personality"]
-extern "C" fn eh_personality() {}

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.4.6'
+  s.version          = '0.4.7'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -25,7 +25,7 @@ TARGETS=(
   aarch64-apple-tvos-sim
   x86_64-apple-tvos
 )
-VERSION=0.4.6
+VERSION=0.4.7
 
 function generatePlist() {
   min_os_version=0


### PR DESCRIPTION
This prepares a patch release of the core extension. Changes since the last release:

- Improve the quality of error messages for statements on raw tables.
- Add a "soft-clear" flag to `powersync_clear()` that preserves oplog state while clearing visible data.
- Build static libraries to prepare for a native SDK.
- Build independent iOS libraries to prepare for build hooks on Dart.

Another small change is that this removes the `eh_personality` function from the `static` crate which doesn't seem to be necessary. It looks like we wouldn't need it on the dynamic crate either, but it causes less damage there and since the dynamic library is used in more places I don't want to mess with it.