### PR TITLE
Build independent shared libraries for Android

### DIFF
--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -65,9 +65,16 @@ runs:
       shell: bash
       run: |
         cp target/aarch64-linux-android/release/libpowersync.a libpowersync_aarch64.android.a
+        cp target/aarch64-linux-android/release/libpowersync.so libpowersync_aarch64.android.so
+
         cp target/armv7-linux-androideabi/release/libpowersync.a libpowersync_armv7.android.a
+        cp target/armv7-linux-androideabi/release/libpowersync.so libpowersync_armv7.android.so
+
         cp target/i686-linux-android/release/libpowersync.a libpowersync_x86.android.a
+        cp target/i686-linux-android/release/libpowersync.so libpowersync_x86.android.so
+
         cp target/x86_64-linux-android/release/libpowersync.a libpowersync_x64.android.a
+        cp target/x86_64-linux-android/release/libpowersync.so libpowersync_x64.android.so
 
     - name: Upload static libraries
       uses: actions/upload-artifact@v4
@@ -76,3 +83,4 @@ runs:
         retention-days: 14
         path: |
           *.a
+          *.so

--- a/dart/test/utils/native_test_utils.dart
+++ b/dart/test/utils/native_test_utils.dart
@@ -69,10 +69,10 @@ String resolvePowerSyncLibrary() {
           Abi.macosArm64 => 'libpowersync_aarch64.macos.dylib',
           Abi.windowsX64 => 'powersync_x64.dll',
           Abi.windowsArm64 => 'powersync_aarch64.dll',
-          Abi.linuxX64 => 'libpowersync_x64.so',
-          Abi.linuxArm => 'libpowersync_armv7.so',
-          Abi.linuxArm64 => 'libpowersync_aarch64.so',
-          Abi.linuxRiscv64 => 'libpowersync_riscv64gc.so',
+          Abi.linuxX64 => 'libpowersync_x64.linux.so',
+          Abi.linuxArm => 'libpowersync_armv7.linux.so',
+          Abi.linuxArm64 => 'libpowersync_aarch64.linux.so',
+          Abi.linuxRiscv64 => 'libpowersync_riscv64gc.linux.so',
           _ => throw ArgumentError(
               'Unsupported processor architecture "${Abi.current()}". '
               'Please open an issue on GitHub to request it.',

--- a/tool/build_linux.sh
+++ b/tool/build_linux.sh
@@ -8,7 +8,7 @@ function compile() {
   cargo build -p powersync_loadable -Z build-std=panic_abort,core,alloc --release --target $triple
   cargo build -p powersync_static -Z build-std=panic_abort,core,alloc --release --target $triple
 
-  mv "target/$triple/release/libpowersync.so" "libpowersync_$suffix.so"
+  mv "target/$triple/release/libpowersync.so" "libpowersync_$suffix.linux.so"
   mv "target/$triple/release/libpowersync.a" "libpowersync_$suffix.linux.a"
 }
 


### PR DESCRIPTION
This is the Android follow-up to https://github.com/powersync-ja/powersync-sqlite-core/pull/135. Because 36 attachments to each release are apparently not enough.

The motivation is the same: For Dart build hooks, we want to be able to download a `.so` for each Android ABI independently instead of depending on a Gradle buildscript.
Because the file names clash with Linux builds, this also renames Linux binaries to `.linux.so` (used to just be `.so`).