### PR TITLE
Soft clear: Delete `$local` bucket

### DIFF
--- a/crates/core/src/view_admin.rs
+++ b/crates/core/src/view_admin.rs
@@ -159,6 +159,7 @@ fn powersync_clear_impl(
         local_db.exec_safe("DELETE FROM ps_oplog; DELETE FROM ps_buckets")?;
     } else {
         local_db.exec_safe("UPDATE ps_buckets SET last_applied_op = 0")?;
+        local_db.exec_safe("DELETE FROM ps_buckets WHERE name = '$local'")?;
     }
 
     // language=SQLite

--- a/dart/test/sync_test.dart
+++ b/dart/test/sync_test.dart
@@ -376,12 +376,16 @@ void _syncTests<T>({
     pushSyncData('a', '1', 'row-0', 'PUT', {'col': 'hi'});
     pushCheckpointComplete();
 
-    expect(db.select('SELECT * FROM items'), hasLength(1));
+    db.execute(
+        'insert into items (id, col) values (uuid(), ?)', ['local item']);
+    expect(db.select('SELECT * FROM items'), hasLength(2));
 
     // Soft clear
     db.execute('SELECT powersync_clear(2)');
     db.select('select powersync_replace_schema(?)', [json.encode(testSchema)]);
     expect(db.select('SELECT * FROM items'), hasLength(0));
+    expect(
+        db.select(r"SELECT * FROM ps_buckets WHERE name = '$local'"), isEmpty);
 
     final request = invokeControl('start', null);
     expect(


### PR DESCRIPTION
The soft clear mode is supposed to keep buckets around to allow them to restore faster on the next sync.

The `$local` bucket needs to be deleted though, because otherwise the sync would be stuck (there would be no data in `ps_crud` to upload while the `$local` bucket prevents new checkpoints from being applied).

This ensures resuming sync works after a soft clear by deleting the bucket and writing a test for that scenario.