### PR TITLE
Refactor view management

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -64,7 +64,6 @@ fn init_extension(db: *mut sqlite::sqlite3) -> Result<(), PowerSyncError> {
     let state = Rc::new(DatabaseState::new());
 
     crate::version::register(db)?;
-    crate::views::register(db)?;
     crate::uuid::register(db)?;
     crate::diff::register(db)?;
     crate::fix_data::register(db)?;

--- a/crates/core/src/schema/inspection.rs
+++ b/crates/core/src/schema/inspection.rs
@@ -1,0 +1,81 @@
+use alloc::borrow::ToOwned;
+use alloc::{format, vec};
+use alloc::{string::String, vec::Vec};
+use powersync_sqlite_nostd::Connection;
+use powersync_sqlite_nostd::{self as sqlite, ResultCode};
+
+use crate::error::{PSResult, PowerSyncError};
+use crate::util::quote_identifier;
+
+/// An existing PowerSync-managed view that was found in the schema.
+#[derive(PartialEq)]
+pub struct ExistingView {
+    /// The name of the view itself.
+    pub name: String,
+    /// SQL contents of the `CREATE VIEW` statement.
+    pub sql: String,
+    /// SQL contents of all triggers implementing deletes by forwarding to
+    /// `ps_data` and `ps_crud`.
+    pub delete_trigger_sql: String,
+    /// SQL contents of the trigger implementing inserts on this view.
+    pub insert_trigger_sql: String,
+    /// SQL contents of the trigger implementing updates on this view.
+    pub update_trigger_sql: String,
+}
+
+impl ExistingView {
+    pub fn list(db: *mut sqlite::sqlite3) -> Result<Vec<Self>, PowerSyncError> {
+        let mut results = vec![];
+        let stmt = db.prepare_v2("
+SELECT
+    view.name,
+    view.sql,
+    ifnull(group_concat(trigger1.sql, ';\n' ORDER BY trigger1.name DESC), ''),
+    ifnull(trigger2.sql, ''),
+    ifnull(trigger3.sql, '')
+    FROM sqlite_master view
+    LEFT JOIN sqlite_master trigger1
+        ON trigger1.tbl_name = view.name AND trigger1.type = 'trigger' AND trigger1.name GLOB 'ps_view_delete*'
+    LEFT JOIN sqlite_master trigger2
+        ON trigger2.tbl_name = view.name AND trigger2.type = 'trigger' AND trigger2.name GLOB 'ps_view_insert*'
+    LEFT JOIN sqlite_master trigger3
+        ON trigger3.tbl_name = view.name AND trigger3.type = 'trigger' AND trigger3.name GLOB 'ps_view_update*'
+    WHERE view.type = 'view' AND view.sql GLOB  '*-- powersync-auto-generated'
+    GROUP BY view.name;
+        ").into_db_result(db)?;
+
+        while stmt.step()? == ResultCode::ROW {
+            let name = stmt.column_text(0)?.to_owned();
+            let sql = stmt.column_text(1)?.to_owned();
+            let delete = stmt.column_text(2)?.to_owned();
+            let insert = stmt.column_text(3)?.to_owned();
+            let update = stmt.column_text(4)?.to_owned();
+
+            results.push(ExistingView {
+                name,
+                sql,
+                delete_trigger_sql: delete,
+                insert_trigger_sql: insert,
+                update_trigger_sql: update,
+            });
+        }
+
+        Ok(results)
+    }
+
+    pub fn drop_by_name(db: *mut sqlite::sqlite3, name: &str) -> Result<(), PowerSyncError> {
+        let q = format!("DROP VIEW IF EXISTS {:}", quote_identifier(name));
+        db.exec_safe(&q)?;
+        Ok(())
+    }
+
+    pub fn create(&self, db: *mut sqlite::sqlite3) -> Result<(), PowerSyncError> {
+        Self::drop_by_name(db, &self.name)?;
+        db.exec_safe(&self.sql).into_db_result(db)?;
+        db.exec_safe(&self.delete_trigger_sql).into_db_result(db)?;
+        db.exec_safe(&self.insert_trigger_sql).into_db_result(db)?;
+        db.exec_safe(&self.update_trigger_sql).into_db_result(db)?;
+
+        Ok(())
+    }
+}

--- a/crates/core/src/schema/mod.rs
+++ b/crates/core/src/schema/mod.rs
@@ -1,3 +1,4 @@
+pub mod inspection;
 mod management;
 mod table_info;
 

--- a/crates/core/src/schema/table_info.rs
+++ b/crates/core/src/schema/table_info.rs
@@ -29,10 +29,6 @@ pub struct RawTable {
 }
 
 impl Table {
-    pub fn from_json(text: &str) -> Result<Self, serde_json::Error> {
-        serde_json::from_str(text)
-    }
-
     pub fn view_name(&self) -> &str {
         self.view_name_override
             .as_deref()


### PR DESCRIPTION
This replaces intermediate SQL logic used to setup views with a simple filter implemented in Rust. This makes the flow much easier to understand, and avoids re-parsing tables from JSON multiple times.

Specifically, this removes the following internal SQL functions and views:

- The `powersync_views` view and associated triggers.
- `powersync_exec`
- `powersync_view_sql`, `powersync_trigger_delete_sql`, `powersync_trigger_insert_sql`, `powersync_trigger_update_sql`.

Instead, it adds the `ExistingView` struct which holds the same fields as `powersync_views` and uses the same query to read views. When we apply a schema, we use the parsed schema struct to find necessary updates instead of expressing that in SQL. The functions to create SQL for views and triggers has also been refactored to be Rust-internal.

I've kept `powersync_drop_view` because it's used in a down migration we can't change. I had to migrate one up migration to use the new direct Rust calls in favor of the SQL layer, but the behavior should be the same.

These changes are covered by existing tests. This still keeps `powersync_tables` around, I will refactor that away in a follow-up PR.