### PR TITLE
Prepare 0.4.9 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powersync_core"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "bytes",
  "const_format",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "powersync_core",
  "powersync_sqlite_nostd",
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "cc",
  "powersync_core",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite_nostd"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "bindgen",
  "num-derive 0.4.2",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_static"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "powersync_core",
  "powersync_sqlite_nostd",
@@ -525,7 +525,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sqlite3"
-version = "0.4.8"
+version = "0.4.9"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 inherits = "wasm"
 
 [workspace.package]
-version = "0.4.8"
+version = "0.4.9"
 edition = "2024"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.powersync"
-version = "0.4.8"
+version = "0.4.9"
 description = "PowerSync Core SQLite Extension"
 
 val localRepo = uri("build/repository/")

--- a/android/src/prefab/prefab.json
+++ b/android/src/prefab/prefab.json
@@ -2,5 +2,5 @@
   "name": "powersync_sqlite_core",
   "schema_version": 2,
   "dependencies": [],
-  "version": "0.4.8"
+  "version": "0.4.9"
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,7 +15,7 @@ name = "powersync_core"
 crate-type = ["rlib"]
 
 [dependencies]
-powersync_sqlite_nostd = { version = "=0.4.8", path = "../sqlite_nostd" }
+powersync_sqlite_nostd = { version = "=0.4.9", path = "../sqlite_nostd" }
 bytes = { version = "1.4", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 num-derive = "0.3"

--- a/crates/core/build.rs
+++ b/crates/core/build.rs
@@ -1,10 +1,18 @@
 use std::process::Command;
 fn main() {
-    // note: add error checking yourself.
-    let output = Command::new("git")
+    let mut git_hash = Command::new("git")
         .args(&["rev-parse", "HEAD"])
         .output()
-        .unwrap();
-    let git_hash = String::from_utf8(output.stdout).unwrap();
+        .ok()
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .unwrap_or_default();
+
+    if git_hash.is_empty() {
+        // We can't compute the git hash for versions pushed to crates.io. That's fine, we'll use a
+        // separate designator for that instead. The designator needs to be 8 chars in length since
+        // that's the substring used in version numbers.
+        git_hash = "cratesio".to_owned();
+    }
+
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 }

--- a/crates/core/src/constants.rs
+++ b/crates/core/src/constants.rs
@@ -12,5 +12,9 @@ pub const MIN_SQLITE_VERSION_NUMBER: c_int = 3044000;
 pub const SUBTYPE_JSON: u32 = 'J' as u32;
 
 pub fn short_git_hash() -> &'static str {
-    &FULL_GIT_HASH[..8]
+    if FULL_GIT_HASH.len() >= 8 {
+        &FULL_GIT_HASH[..8]
+    } else {
+        "no-git-unknown"
+    }
 }

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.4.8'
+  s.version          = '0.4.9'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -25,7 +25,7 @@ TARGETS=(
   aarch64-apple-tvos-sim
   x86_64-apple-tvos
 )
-VERSION=0.4.8
+VERSION=0.4.9
 
 function generatePlist() {
   min_os_version=0


### PR DESCRIPTION
This prepares version `0.4.9`, which contains the following changes:

- Support stable Rust 1.91.
- Publish core extension to crates.io
- Simplify applying view and table changes in schema management.
