### PR TITLE
Fix cargo publish paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,7 +243,7 @@ jobs:
 
       - name: Publish powersync_sqlite_nostd
         run: cargo publish
-        working-directory: crates/core
+        working-directory: crates/sqlite_nostd
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
       - name: Publish powersync_core


### PR DESCRIPTION
I meant to upload `sqlite_nostd` first and `core` later, the current release workflow would attempt to publish `core` twice.

I've [manually started this flow](https://github.com/powersync-ja/powersync-sqlite-core/actions/runs/19137392864) once to verify that publishing works with this.