### PR TITLE
Prepare 0.4.10 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powersync_core"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "bytes",
  "const_format",
@@ -350,7 +350,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "powersync_core",
  "powersync_sqlite_nostd",
@@ -358,7 +358,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "cc",
  "powersync_core",
@@ -367,7 +367,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite_nostd"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "bindgen",
  "num-derive 0.4.2",
@@ -376,7 +376,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_static"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "powersync_core",
  "powersync_sqlite_nostd",
@@ -525,7 +525,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sqlite3"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 inherits = "wasm"
 
 [workspace.package]
-version = "0.4.9"
+version = "0.4.10"
 edition = "2024"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.powersync"
-version = "0.4.9"
+version = "0.4.10"
 description = "PowerSync Core SQLite Extension"
 
 val localRepo = uri("build/repository/")

--- a/android/src/prefab/prefab.json
+++ b/android/src/prefab/prefab.json
@@ -2,5 +2,5 @@
   "name": "powersync_sqlite_core",
   "schema_version": 2,
   "dependencies": [],
-  "version": "0.4.9"
+  "version": "0.4.10"
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -15,7 +15,7 @@ name = "powersync_core"
 crate-type = ["rlib"]
 
 [dependencies]
-powersync_sqlite_nostd = { version = "=0.4.9", path = "../sqlite_nostd" }
+powersync_sqlite_nostd = { version = "=0.4.10", path = "../sqlite_nostd" }
 bytes = { version = "1.4", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 num-derive = "0.3"

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.4.9'
+  s.version          = '0.4.10'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -25,7 +25,7 @@ TARGETS=(
   aarch64-apple-tvos-sim
   x86_64-apple-tvos
 )
-VERSION=0.4.9
+VERSION=0.4.10
 
 function generatePlist() {
   min_os_version=0


### PR DESCRIPTION
The only change since 0.4.9 is support for request metadata in the `start` command of the sync client.