### PR TITLE
Restructure static libraries attached to releases

### DIFF
--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -61,26 +61,18 @@ runs:
         path: android/build/distributions/powersync_android.zip
         if-no-files-found: error
 
-    - name: Copy static libraries
+    - name: Copy individual libraries
       shell: bash
       run: |
-        cp target/aarch64-linux-android/release/libpowersync.a libpowersync_aarch64.android.a
         cp target/aarch64-linux-android/release/libpowersync.so libpowersync_aarch64.android.so
-
-        cp target/armv7-linux-androideabi/release/libpowersync.a libpowersync_armv7.android.a
         cp target/armv7-linux-androideabi/release/libpowersync.so libpowersync_armv7.android.so
-
-        cp target/i686-linux-android/release/libpowersync.a libpowersync_x86.android.a
         cp target/i686-linux-android/release/libpowersync.so libpowersync_x86.android.so
-
-        cp target/x86_64-linux-android/release/libpowersync.a libpowersync_x64.android.a
         cp target/x86_64-linux-android/release/libpowersync.so libpowersync_x64.android.so
 
-    - name: Upload static libraries
+    - name: Upload individual libraries
       uses: actions/upload-artifact@v4
       with:
         name: android-static
         retention-days: 14
         path: |
-          *.a
           *.so

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,6 +185,9 @@ jobs:
         with:
           name: android-static
 
+      - name: Create archive of static libs for Kotlin
+        run: zip static_libs.zip *.lib *.a
+
       - name: List libraries
         run: ls -al
 
@@ -194,10 +197,9 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           gh release upload "${{ needs.draft_release.outputs.tag }}" *.dll
-          gh release upload "${{ needs.draft_release.outputs.tag }}" *.lib
           gh release upload "${{ needs.draft_release.outputs.tag }}" *.dylib
           gh release upload "${{ needs.draft_release.outputs.tag }}" *.so
-          gh release upload "${{ needs.draft_release.outputs.tag }}" *.a
+          gh release upload "${{ needs.draft_release.outputs.tag }}" static_libs.zip
 
   publish_wasm:
     name: Publish WASM builds

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -95,10 +95,6 @@ val buildRust = tasks.register<Exec>("buildRust") {
     rustCompilation("powersync_loadable", "./android/build/intermediates/jniLibs")
 }
 
-val buildRustStatic = tasks.register<Exec>("buildRustStatic") {
-    rustCompilation("powersync_static")
-}
-
 val prefabAar = tasks.register<Zip>("prefabAar") {
     dependsOn(buildRust)
 
@@ -218,5 +214,5 @@ val zipPublication by tasks.registering(Zip::class) {
 }
 
 tasks.named("build") {
-    dependsOn(prefabAar, buildRustStatic)
+    dependsOn(prefabAar)
 }

--- a/crates/static/Cargo.toml
+++ b/crates/static/Cargo.toml
@@ -22,4 +22,5 @@ features = []
 
 [features]
 nightly = []
-default = ["powersync_core/static"]
+# Whether to expect SQLite to be linked statically as well.
+static = ["powersync_core/static"]

--- a/crates/static/README.md
+++ b/crates/static/README.md
@@ -1,1 +1,7 @@
 Builds the core extension as a static library, exposing the `powersync_init_static` function to load it.
+
+We only use this crate to compile for watchOS, since the regular `loadable` build compiling to a dylib
+doesn't support that platform.
+
+Most users should probably compile the `loadable` crate instead, which also emits a static library. If
+SQLite is linked statically, compiling `loadable` with the `static` feature enabled works.

--- a/tool/build_linux.sh
+++ b/tool/build_linux.sh
@@ -6,7 +6,6 @@ function compile() {
   local suffix=$2
 
   cargo build -p powersync_loadable -Z build-std=panic_abort,core,alloc --features nightly --release --target $triple
-  cargo build -p powersync_static -Z build-std=panic_abort,core,alloc --features nightly --release --target $triple
 
   mv "target/$triple/release/libpowersync.so" "libpowersync_$suffix.linux.so"
   mv "target/$triple/release/libpowersync.a" "libpowersync_$suffix.linux.a"

--- a/tool/build_macos.sh
+++ b/tool/build_macos.sh
@@ -12,15 +12,32 @@ function compile() {
   mv "target/$triple/release/libpowersync.a" "libpowersync_$suffix.$os.a"
 }
 
+function compile_static() {
+  local triple=$1
+  local suffix=$2
+  local os=$3
+
+  cargo build -p powersync_static -Z build-std=panic_abort,core,alloc --features nightly --release --target $triple
+
+  mv "target/$triple/release/libpowersync.a" "libpowersync_$suffix.$os.a"
+}
+
 case "$1" in
   x64)
     compile x86_64-apple-darwin x64 macos
     compile x86_64-apple-ios x64 ios-sim
+    compile x86_64-apple-tvos x64 tvos-sim
+    compile_static x86_64-apple-watchos-sim x64 watchos-sim
     ;;
   aarch64)
     compile aarch64-apple-darwin aarch64 macos
     compile aarch64-apple-ios-sim aarch64 ios-sim
     compile aarch64-apple-ios aarch64 ios
+    compile aarch64-apple-tvos aarch64 tvos
+    compile aarch64-apple-tvos-sim aarch64 tvos-sim
+    compile_static aarch64-apple-watchos aarch64 watchos
+    compile_static aarch64-apple-watchos aarch64 watchos-sim
+    compile_static arm64_32-apple-watchos arm64_32 watchos
     ;;
   *)
     echo "Unknown architecture"

--- a/tool/build_macos.sh
+++ b/tool/build_macos.sh
@@ -7,7 +7,6 @@ function compile() {
   local os=$3
 
   cargo build -p powersync_loadable -Z build-std=panic_abort,core,alloc --features nightly --release --target $triple
-  cargo build -p powersync_static -Z build-std=panic_abort,core,alloc --features nightly --release --target $triple
 
   mv "target/$triple/release/libpowersync.dylib" "libpowersync_$suffix.$os.dylib"
   mv "target/$triple/release/libpowersync.a" "libpowersync_$suffix.$os.a"

--- a/tool/build_windows.sh
+++ b/tool/build_windows.sh
@@ -6,7 +6,6 @@ function compile() {
   local suffix=$2
 
   cargo build -p powersync_loadable -Z build-std=panic_abort,core,alloc --features=nightly --release --target $triple
-  cargo build -p powersync_static -Z build-std=panic_abort,core,alloc --features=nightly --release --target $triple
 
   mv "target/$triple/release/powersync.dll" "powersync_$suffix.dll"
   mv "target/$triple/release/powersync.lib" "powersync_$suffix.lib"

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -187,7 +187,7 @@ for TARGET in ${TARGETS[@]}; do
     cargo build \
       -p powersync_static \
       --profile release_apple \
-      --features nightly \
+      --features static,nightly \
       --target $TARGET \
       -Zbuild-std
   else


### PR DESCRIPTION
In this repository, "static" is a bit of an overloaded term:

1. It can refer to whether the core extension library itself is built as a static library.
2. It can refer to whether the core extension invokes SQLite APIs dynamically (by being given a bunch of function pointers at runtime) or statically (by invoking functions directly).

This gives us four possibilities, all of which have their use:

1. Static core extension library + static SQLite invocations: This is used by the `libpowersync-wasm.a` build for the Dart SDK and watchOS builds in the XCFramework. Even though it doesn't break anything, static SQLite invocations for watchOS was likely a mistake. It's only used in the Kotlin and Swift SDK, but approach 2 would be better for that. We also build Android and Desktop variants of this build, but those aren't used. 
2. Static core extension library + dynamic SQLite invocations: This is not currently used, but it would be very useful to have that in the Kotlin SDK! We can statically link external code in the Kotlin SDK, and this build would enable us to link the core extension while still supporting arbitrary SQLite versions (in particular, both sqlite3 and sqlite3multipleciphers).
3. Dynamic core extension library + static SQLite invocations. We use this for the WA-sqlite WASM side-module.
4. Dynamic core extension library + dynamic SQLite invocations: We use this to load the core extension in the Dart, React Native, Node, Capacitor, Kotlin (except for watchOS), C# and Swift SDKs.

This PR removes a few unused builds and prepares statically-linked libraries with dynamic SQLite invocations for Kotlin:

1. The `.a` and `.lib` files attached to our releases use build type 1. They were meant to be linked statically into Dart applications once Dart supports that, but it's unclear whether Dart will ever add support for that. Also, they should have probably used build type 2 instead so that we can still let the app developer decide how to link SQLite .
2. This removes static core extension builds for Android, and adds static core extension builds with dynamic SQLite invocations for all targets we support with Kotlin/Native. This allows linking the core extension from Kotlin.

Linking the core extension through Kotlin makes the SDK easier to use (since users don't have to add an additional native dependency), and unblocks native Linux and Windows support for the Kotlin SDK. I've manually tested this setup in the Kotlin SDK.