### PR TITLE
Update status to disconnected on eof

### DIFF
--- a/crates/core/src/sync/streaming_sync.rs
+++ b/crates/core/src/sync/streaming_sync.rs
@@ -563,6 +563,8 @@ impl StreamingSyncIteration {
                     continue;
                 }
                 SyncEvent::StreamEnded => {
+                    self.status
+                        .update(|s| s.disconnect(), &mut event.instructions);
                     break false;
                 }
                 SyncEvent::DidRefreshToken => {

--- a/dart/test/sync_test.dart
+++ b/dart/test/sync_test.dart
@@ -208,6 +208,11 @@ void _syncTests<T>({
     ]);
     expect(invokeControl('connection', 'end'), [
       {
+        'UpdateSyncStatus': {
+          'status': containsPair('connected', false),
+        }
+      },
+      {
         'CloseSyncStream': {'hide_disconnect': false}
       }
     ]);


### PR DESCRIPTION
A `/sync/stream` ending is always an unexpected event. SDKs would reconnect in that case, but they're clearly disconnected during the retry delay. This should be reflected on the sync status emitted by the core extension.

(this isn't an issue in practice because all our SDKs manually update their status in this case. But they shouldn't have to do that, and I ran into this testing a new Swift implementation)