### PR TITLE
Update Rust to 1.96.0

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -22,6 +22,11 @@ rustflags = [
     "-C", "link-arg=-lgcc_eh",
 ]
 
+[target.'cfg(target_family = "wasm")']
+rustflags = [
+    "-C", "link-arg=--allow-undefined",
+]
+
 [target.x86_64-unknown-linux-gnu]
 linker = "x86_64-linux-gnu-gcc"
 

--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -25,8 +25,8 @@ runs:
     - name: Setup
       shell: bash
       run: |
-        rustup toolchain install nightly-2025-12-05-x86_64-unknown-linux-gnu
-        rustup component add rust-src --toolchain nightly-2025-12-05-x86_64-unknown-linux-gnu
+        rustup toolchain install nightly-2026-04-10-x86_64-unknown-linux-gnu
+        rustup component add rust-src --toolchain nightly-2026-04-10-x86_64-unknown-linux-gnu
         rustup target add \
           aarch64-linux-android \
           armv7-linux-androideabi \

--- a/.github/actions/linux/action.yml
+++ b/.github/actions/linux/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Install Rust Nightly
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: nightly-2025-12-05
+        toolchain: nightly-2026-04-10
         components: rust-src
         targets: aarch64-unknown-linux-gnu,x86_64-unknown-linux-gnu,i686-unknown-linux-gnu,riscv64gc-unknown-linux-gnu,armv7-unknown-linux-gnueabihf
     

--- a/.github/actions/macos/action.yml
+++ b/.github/actions/macos/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Install Rust Nightly
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: nightly-2025-12-05
+        toolchain: nightly-2026-04-10
         components: rust-src
         targets: x86_64-apple-darwin,aarch64-apple-darwin
     

--- a/.github/actions/wasm/action.yml
+++ b/.github/actions/wasm/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Install Rust Nightly
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: nightly-2025-12-05
+        toolchain: nightly-2026-04-10
         components: rust-src
 
     - name: Setup emsdk

--- a/.github/actions/windows/action.yml
+++ b/.github/actions/windows/action.yml
@@ -7,7 +7,7 @@ runs:
     - name: Install Rust Nightly
       uses: dtolnay/rust-toolchain@stable
       with:
-        toolchain: nightly-2025-12-05
+        toolchain: nightly-2026-04-10
         components: rust-src
         targets: x86_64-pc-windows-msvc,aarch64-pc-windows-msvc,i686-pc-windows-msvc
 

--- a/.github/actions/xcframework/action.yml
+++ b/.github/actions/xcframework/action.yml
@@ -7,8 +7,8 @@ runs:
     - name: Setup
       shell: bash
       run: |
-        rustup toolchain install nightly-2025-12-05-aarch64-apple-darwin
-        rustup component add rust-src --toolchain nightly-2025-12-05-aarch64-apple-darwin
+        rustup toolchain install nightly-2026-04-10-aarch64-apple-darwin
+        rustup component add rust-src --toolchain nightly-2026-04-10-aarch64-apple-darwin
         rustup target add \
           x86_64-apple-darwin \
           aarch64-apple-darwin \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Install Rust Nightly
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly-2025-12-05
+          toolchain: nightly-2026-04-10
           components: rust-src,rustfmt,clippy
 
       - name: Check formatting
@@ -201,7 +201,7 @@ jobs:
       - name: Install Rust Nightly
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: nightly-2025-12-05
+          toolchain: nightly-2026-04-10
           components: rust-src
 
       - name: Install valgrind

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -9,6 +9,7 @@ authors.workspace = true
 keywords.workspace = true
 description = "The PowerSync SQLite extension"
 readme = "README.md"
+rust-version = "1.96"
 
 [lib]
 name = "powersync_core"

--- a/crates/core/src/bson/de.rs
+++ b/crates/core/src/bson/de.rs
@@ -1,3 +1,4 @@
+use core::assert_matches;
 use serde::{
     de::{
         self, DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, SeqAccess, VariantAccess,
@@ -248,10 +249,7 @@ impl<'de> SeqAccess<'de> for Deserializer<'de> {
         }
 
         // Skip name
-        assert!(matches!(
-            self.position,
-            DeserializerPosition::BeforeName { .. }
-        ));
+        assert_matches!(self.position, DeserializerPosition::BeforeName { .. });
         self.prepare_to_read(true)?;
 
         // And deserialize value!

--- a/crates/core/src/bson/mod.rs
+++ b/crates/core/src/bson/mod.rs
@@ -52,7 +52,7 @@ mod test {
         let bson = b"\x1b\x00\x00\x00\x10token_expires_in\x00<\x00\x00\x00\x00";
 
         let expected: SyncLine = from_bytes(bson.as_slice()).expect("should deserialize");
-        assert!(matches!(expected, SyncLine::KeepAlive(TokenExpiresIn(60))))
+        assert_matches!(expected, SyncLine::KeepAlive(TokenExpiresIn(60)))
     }
 
     #[test]

--- a/crates/core/src/bson/mod.rs
+++ b/crates/core/src/bson/mod.rs
@@ -16,6 +16,7 @@ pub fn from_bytes<'de, T: Deserialize<'de>>(bytes: &'de [u8]) -> Result<T, BsonE
 #[cfg(test)]
 mod test {
     use alloc::{vec, vec::Vec};
+    use core::assert_matches;
 
     use crate::sync::line::{SyncLine, TokenExpiresIn};
 

--- a/crates/core/src/fix_data.rs
+++ b/crates/core/src/fix_data.rs
@@ -159,7 +159,7 @@ mod test {
     use super::remove_duplicate_key_encoding;
 
     fn assert_unaffected(source: &str) {
-        assert!(matches!(remove_duplicate_key_encoding(source), None));
+        assert_matches!(remove_duplicate_key_encoding(source), None);
     }
 
     #[test]

--- a/crates/core/src/fix_data.rs
+++ b/crates/core/src/fix_data.rs
@@ -157,6 +157,7 @@ pub fn register(db: *mut sqlite::sqlite3) -> Result<(), ResultCode> {
 mod test {
 
     use super::remove_duplicate_key_encoding;
+    use core::assert_matches;
 
     fn assert_unaffected(source: &str) {
         assert_matches!(remove_duplicate_key_encoding(source), None);

--- a/crates/core/src/schema/raw_table.rs
+++ b/crates/core/src/schema/raw_table.rs
@@ -324,6 +324,7 @@ pub fn generate_raw_table_trigger(
 #[cfg(test)]
 mod test {
     use alloc::{string::ToString, vec};
+    use core::assert_matches;
 
     use crate::schema::{PendingStatementValue, raw_table::InferredTableStructure};
 

--- a/crates/core/src/schema/raw_table.rs
+++ b/crates/core/src/schema/raw_table.rs
@@ -340,19 +340,19 @@ mod test {
             r#"INSERT INTO "tbl" (id, "foo", "bar") VALUES (?1, ?2, ?3) ON CONFLICT (id) DO UPDATE SET "foo" = ?2, "bar" = ?3"#
         );
         assert_eq!(put.params.len(), 3);
-        assert!(matches!(put.params[0], PendingStatementValue::Id));
-        assert!(matches!(
+        assert_matches!(put.params[0], PendingStatementValue::Id);
+        assert_matches!(
             put.params[1],
             PendingStatementValue::Column(ref name) if name == "foo"
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             put.params[2],
             PendingStatementValue::Column(ref name) if name == "bar"
-        ));
+        );
 
         let delete = structure.infer_delete_stmt();
         assert_eq!(delete.sql, r#"DELETE FROM "tbl" WHERE id = ?"#);
         assert_eq!(delete.params.len(), 1);
-        assert!(matches!(delete.params[0], PendingStatementValue::Id));
+        assert_matches!(delete.params[0], PendingStatementValue::Id);
     }
 }

--- a/crates/core/src/schema/table_info.rs
+++ b/crates/core/src/schema/table_info.rs
@@ -357,7 +357,7 @@ impl<'de> Deserialize<'de> for PendingStatement {
     }
 }
 
-#[derive(Deserialize)]
+#[derive(Deserialize, Debug)]
 pub enum PendingStatementValue {
     /// Bind to the PowerSync row id of the affected row.
     Id,

--- a/crates/core/src/sync/line.rs
+++ b/crates/core/src/sync/line.rs
@@ -373,6 +373,7 @@ impl<'a, 'de: 'a> Deserialize<'de> for OplogData<'a> {
 mod tests {
 
     use alloc::string::ToString;
+    use core::assert_matches;
 
     use super::*;
 

--- a/crates/core/src/sync/line.rs
+++ b/crates/core/src/sync/line.rs
@@ -382,15 +382,15 @@ mod tests {
 
     #[test]
     fn parse_token_expires_in() {
-        assert!(matches!(
+        assert_matches!(
             deserialize(r#"{"token_expires_in": 123}"#),
             SyncLine::KeepAlive(TokenExpiresIn(123))
-        ));
+        );
     }
 
     #[test]
     fn parse_checkpoint() {
-        assert!(matches!(
+        assert_matches!(
             deserialize(r#"{"checkpoint": {"last_op_id": "10", "buckets": []}}"#),
             SyncLine::Checkpoint(Checkpoint {
                 last_op_id: 10,
@@ -398,7 +398,7 @@ mod tests {
                 buckets: _,
                 streams: _,
             })
-        ));
+        );
 
         let SyncLine::Checkpoint(checkpoint) = deserialize(
             r#"{"checkpoint": {"last_op_id": "10", "buckets": [{"bucket": "a", "checksum": 10}]}}"#,
@@ -424,7 +424,7 @@ mod tests {
         assert_eq!(bucket.checksum, 10u32.into());
         assert_eq!(bucket.priority, Some(BucketPriority { number: 1 }));
 
-        assert!(matches!(
+        assert_matches!(
             deserialize(
                 r#"{"checkpoint":{"write_checkpoint":null,"last_op_id":"1","buckets":[{"bucket":"a","checksum":0,"priority":3,"count":1}]}}"#
             ),
@@ -434,7 +434,7 @@ mod tests {
                 buckets: _,
                 streams: _,
             })
-        ));
+        );
     }
 
     #[test]
@@ -471,23 +471,23 @@ mod tests {
 
     #[test]
     fn parse_checkpoint_complete() {
-        assert!(matches!(
+        assert_matches!(
             deserialize(r#"{"checkpoint_complete": {"last_op_id": "10"}}"#),
             SyncLine::CheckpointComplete(CheckpointComplete {
                 // last_op_id: 10
             })
-        ));
+        );
     }
 
     #[test]
     fn parse_checkpoint_partially_complete() {
-        assert!(matches!(
+        assert_matches!(
             deserialize(r#"{"partial_checkpoint_complete": {"last_op_id": "10", "priority": 1}}"#),
             SyncLine::CheckpointPartiallyComplete(CheckpointPartiallyComplete {
                 //last_op_id: 10,
                 priority: BucketPriority { number: 1 }
             })
-        ));
+        );
     }
 
     #[test]
@@ -508,7 +508,7 @@ mod tests {
         assert_eq!(data.data.len(), 1);
         let entry = &data.data[0];
         assert_eq!(entry.checksum, 10u32.into());
-        assert!(matches!(
+        assert_matches!(
             &data.data[0],
             OplogEntry {
                 checksum: _,
@@ -519,19 +519,13 @@ mod tests {
                 subkey: None,
                 data: _,
             }
-        ));
+        );
     }
 
     #[test]
     fn parse_unknown() {
-        assert!(matches!(
-            deserialize("{\"foo\": {}}"),
-            SyncLine::UnknownSyncLine
-        ));
-        assert!(matches!(
-            deserialize("{\"foo\": 123}"),
-            SyncLine::UnknownSyncLine
-        ));
+        assert_matches!(deserialize("{\"foo\": {}}"), SyncLine::UnknownSyncLine);
+        assert_matches!(deserialize("{\"foo\": 123}"), SyncLine::UnknownSyncLine);
     }
 
     #[test]

--- a/crates/loadable/src/lib.rs
+++ b/crates/loadable/src/lib.rs
@@ -1,7 +1,6 @@
 #![no_std]
 #![allow(internal_features)]
-#![cfg_attr(feature = "nightly", feature(core_intrinsics))]
-#![cfg_attr(feature = "nightly", feature(lang_items))]
+#![cfg_attr(feature = "nightly", feature(core_intrinsics, lang_items))]
 
 extern crate alloc;
 

--- a/crates/shell/src/main.rs
+++ b/crates/shell/src/main.rs
@@ -2,7 +2,7 @@
 #![no_std]
 #![allow(internal_features)]
 #![feature(lang_items)]
-#![feature(core_intrinsics)]
+#![cfg_attr(not(test), feature(core_intrinsics))]
 
 use core::ffi::{c_char, c_int};
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2025-12-05"
+channel = "nightly-2026-04-10"

--- a/tool/build_wasm.sh
+++ b/tool/build_wasm.sh
@@ -32,13 +32,13 @@ cp "target/wasm32-unknown-emscripten/wasm_asyncify/powersync.wasm" "libpowersync
 # Static lib.
 # Works for both sync and asyncify builds.
 # Works for both emscripten and wasi.
-# target/wasm32-wasip1/wasm/libpowersync.a
+# target/wasm32-unknown-unknown/wasm/libpowersync.a
 cargo build \
   -p powersync_loadable \
   --profile wasm \
   --no-default-features \
   --features "static nightly" \
   -Z build-std=panic_abort,core,alloc \
-  --target wasm32-wasip1
+  --target wasm32-unknown-unknown
 
-cp "target/wasm32-wasip1/wasm/libpowersync.a" "libpowersync-wasm.a"
+cp "target/wasm32-unknown-unknown/wasm/libpowersync.a" "libpowersync-wasm.a"


### PR DESCRIPTION
Rust 1.96.0 has been released, and stabilizes `assert_matches!`. This updates the toolchain and adopts that macro (we've used it before, but later removed our usages to support stable Rust).

Rust stopped passing `-Wl,--allow-undefined` to the wasm linker by default, which means that we get linker errors about undefined sqlite symbols now. We intentionally want that for the static library build though, as the SDK (or `wa-sqlite` fork) will link that in the end. We could add explicit wasm import annotations to these functions, but manually passing the linker arg seems easier.