### PR TITLE
Helpers to move between raw tables and ps_untyped

### DIFF
--- a/crates/core/src/schema/mod.rs
+++ b/crates/core/src/schema/mod.rs
@@ -4,7 +4,9 @@ mod management;
 mod raw_table;
 mod table_info;
 
-use alloc::{rc::Rc, vec::Vec};
+use core::{ffi::c_void, fmt::Write};
+
+use alloc::{format, rc::Rc, vec::Vec};
 pub use common::{ColumnFilter, SchemaTable};
 use powersync_sqlite_nostd::{self as sqlite, Connection, Context, Value, args};
 pub use raw_table::InferredSchemaCache;
@@ -17,9 +19,12 @@ pub use table_info::{
 
 use crate::{
     error::{PSResult, PowerSyncError},
-    schema::raw_table::generate_raw_table_trigger,
+    ext::SafeManagedStmt,
+    schema::raw_table::{InferredTableStructure, generate_raw_table_trigger},
     state::DatabaseState,
-    utils::WriteType,
+    sync::RawTableWithCachedStatements,
+    utils::{SqlBuffer, WriteType},
+    views::table_columns_to_json_object,
 };
 
 #[derive(Deserialize, Default)]
@@ -29,27 +34,157 @@ pub struct Schema {
     pub raw_tables: Vec<table_info::RawTable>,
 }
 
+impl Schema {
+    pub fn find_raw_table(&self, name: &str) -> Option<&table_info::RawTable> {
+        self.raw_tables.iter().find(|tbl| tbl.name == name)
+    }
+}
+
+fn create_trigger(
+    context: *mut sqlite::context,
+    args: &[*mut sqlite::value],
+) -> Result<(), PowerSyncError> {
+    // Args: Table (JSON), trigger_name, write_type
+    let table: RawTable =
+        serde_json::from_str(args[0].text()).map_err(PowerSyncError::as_argument_error)?;
+    let trigger_name = args[1].text();
+    let write_type: WriteType = args[2].text().parse()?;
+
+    let db = context.db_handle();
+    let create_trigger_stmt = generate_raw_table_trigger(db, &table, trigger_name, write_type)?;
+    db.exec_safe(&create_trigger_stmt).into_db_result(db)?;
+    Ok(())
+}
+
+enum RawTableMigration<'a> {
+    CreateFromUntyped { table_name: &'a str },
+    DropIntoUntyped { table: RawTable },
+}
+
+impl<'a> RawTableMigration<'a> {
+    fn from_args(args: &'a [*mut sqlite::value]) -> Result<Self, PowerSyncError> {
+        match args[0].text() {
+            "create" => Ok(RawTableMigration::CreateFromUntyped {
+                table_name: args[1].text(),
+            }),
+            "drop" => {
+                let table: RawTable = serde_json::from_str(args[1].text())
+                    .map_err(PowerSyncError::as_argument_error)?;
+                Ok(RawTableMigration::DropIntoUntyped { table })
+            }
+            _ => Err(PowerSyncError::argument_error(
+                "Unknown action for powersync_raw_table_migrate",
+            )),
+        }
+    }
+}
+
+/// Utility to help with migrations involving raw tables.
+///
+/// `powersync_raw_table_migrate('create', $name)` moves existing rows matching the table from
+/// `ps_untyped` into the raw table (to be called after adding the raw table to the schema).
+///
+/// `powersync_raw_table_migrate('drop', $json)` moves rows from the raw table back into
+/// `ps_untyped` (call before removing the raw table from the schema), where `$json` is a JSON
+/// representation of the [`RawTable`] being dropped.
+fn raw_table_migration(
+    context: *mut sqlite::context,
+    args: &[*mut sqlite::value],
+) -> Result<(), PowerSyncError> {
+    let db = context.db_handle();
+    let context = unsafe { DatabaseState::from_context(&context) };
+    let action = RawTableMigration::from_args(args)?;
+
+    // Disable triggers forwarding writes to ps_crud.
+    let _guard = context.sync_local_guard();
+
+    let schema_version = InferredSchemaCache::current_schema_version(db)?;
+
+    match action {
+        RawTableMigration::CreateFromUntyped { table_name } => {
+            // Move data from ps_untyped into this raw table.
+            let Some(schema) = context.view_schema() else {
+                return Err(PowerSyncError::state_error("Schema not initialized"));
+            };
+
+            let Some(table) = schema.find_raw_table(table_name) else {
+                return Err(PowerSyncError::argument_error(format!(
+                    "Raw table {table_name} not found"
+                )));
+            };
+            let delete_untyped =
+                db.prepare_v2("DELETE FROM ps_untyped WHERE type = ? RETURNING id, data")?;
+            delete_untyped.bind_text(1, table_name, powersync_sqlite_nostd::Destructor::STATIC)?;
+            let mut table_statements = RawTableWithCachedStatements::new(table);
+
+            while let ResultCode::ROW = delete_untyped.step()? {
+                let put = table_statements.put_statement(
+                    db,
+                    schema_version,
+                    &context.inferred_schema_cache,
+                )?;
+
+                let id = delete_untyped.column_text(0)?;
+                let data_text = delete_untyped.column_text(1)?;
+                let parsed: serde_json::Value =
+                    serde_json::from_str(data_text).map_err(PowerSyncError::json_local_error)?;
+                let json_object = parsed.as_object().ok_or_else(|| {
+                    PowerSyncError::argument_error("expected oplog data to be an object")
+                })?;
+
+                let rest = put.render_rest_object(&json_object)?;
+                put.bind_for_put(id, &json_object, &rest)?;
+                put.exec(db, table_name, id, Some(&parsed))?;
+            }
+        }
+        RawTableMigration::DropIntoUntyped { table } => {
+            // Copy data from the raw table into ps_untyped, ignoring local-only columns.
+            let local_table_name = table.require_table_name()?;
+            let resolved_table = InferredTableStructure::read_from_database(
+                local_table_name,
+                db,
+                &table.schema.synced_columns,
+            )?;
+            let as_schema_table = SchemaTable::Raw {
+                definition: &table,
+                schema: &resolved_table,
+            };
+
+            let sql = {
+                // Generate an INSERT INTO ps_untyped with a SELECT source transforming existing
+                // rows into JSON objects.
+                let mut buffer = SqlBuffer::new();
+                let fragment = table_columns_to_json_object(&local_table_name, &as_schema_table)?;
+                buffer.push_str("INSERT INTO ps_untyped (type, id, data) SELECT ?, id, ");
+                buffer.push_str(&fragment);
+                buffer.push_str(" FROM ");
+                let _ = buffer.identifier().write_str(local_table_name);
+                buffer.push_char(';');
+                buffer.sql
+            };
+            {
+                let stmt = db.prepare_v2(&sql).into_db_result(db)?;
+                stmt.bind_text(1, &table.name, powersync_sqlite_nostd::Destructor::STATIC)?;
+                stmt.exec().into_db_result(db)?;
+            }
+
+            // Then, delete raw table contents.
+            {
+                let mut truncate_buf = SqlBuffer::new();
+                truncate_buf.push_str("DELETE FROM ");
+                let _ = truncate_buf.identifier().write_str(local_table_name);
+                db.exec_safe(&truncate_buf.sql).into_db_result(db)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
 pub fn register(db: *mut sqlite::sqlite3, state: Rc<DatabaseState>) -> Result<(), ResultCode> {
-    management::register(db, state)?;
+    management::register(db, state.clone())?;
 
     {
-        fn create_trigger(
-            context: *mut sqlite::context,
-            args: &[*mut sqlite::value],
-        ) -> Result<(), PowerSyncError> {
-            // Args: Table (JSON), trigger_name, write_type
-            let table: RawTable =
-                serde_json::from_str(args[0].text()).map_err(PowerSyncError::as_argument_error)?;
-            let trigger_name = args[1].text();
-            let write_type: WriteType = args[2].text().parse()?;
-
-            let db = context.db_handle();
-            let create_trigger_stmt =
-                generate_raw_table_trigger(db, &table, trigger_name, write_type)?;
-            db.exec_safe(&create_trigger_stmt).into_db_result(db)?;
-            Ok(())
-        }
-
         extern "C" fn create_raw_trigger_sqlite(
             context: *mut sqlite::context,
             argc: i32,
@@ -58,6 +193,17 @@ pub fn register(db: *mut sqlite::sqlite3, state: Rc<DatabaseState>) -> Result<()
             let args = args!(argc, args);
             if let Err(e) = create_trigger(context, args) {
                 e.apply_to_ctx("powersync_create_raw_table_crud_trigger", context);
+            }
+        }
+
+        extern "C" fn raw_table_migrate_sqlite(
+            context: *mut sqlite::context,
+            argc: i32,
+            args: *mut *mut sqlite::value,
+        ) {
+            let args = args!(argc, args);
+            if let Err(e) = raw_table_migration(context, args) {
+                e.apply_to_ctx("powersync_raw_table_migrate", context);
             }
         }
 
@@ -71,6 +217,18 @@ pub fn register(db: *mut sqlite::sqlite3, state: Rc<DatabaseState>) -> Result<()
             None,
             None,
         )?;
+
+        db.create_function_v2(
+            "powersync_raw_table_migrate",
+            2,
+            sqlite::UTF8,
+            Some(Rc::into_raw(state) as *mut c_void),
+            Some(raw_table_migrate_sqlite),
+            None,
+            None,
+            Some(DatabaseState::destroy_rc),
+        )?;
     }
+
     Ok(())
 }

--- a/crates/core/src/schema/mod.rs
+++ b/crates/core/src/schema/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     schema::raw_table::{InferredTableStructure, generate_raw_table_trigger},
     state::DatabaseState,
     sync::RawTableWithCachedStatements,
-    utils::{SqlBuffer, WriteType},
+    utils::{SqlBuffer, WriteType, verify_in_transaction},
     views::table_columns_to_json_object,
 };
 
@@ -92,11 +92,8 @@ fn raw_table_migration(
     args: &[*mut sqlite::value],
 ) -> Result<(), PowerSyncError> {
     let db = context.db_handle();
-    if db.get_autocommit() {
-        return Err(PowerSyncError::argument_error(
-            "powersync_raw_table_migrate must be called within a transaction",
-        ));
-    }
+    verify_in_transaction(db)?;
+
     let context = unsafe { DatabaseState::from_context(&context) };
     let action = RawTableMigration::from_args(args)?;
 
@@ -159,7 +156,7 @@ fn raw_table_migration(
                 // Generate an INSERT INTO ps_untyped with a SELECT source transforming existing
                 // rows into JSON objects.
                 let mut buffer = SqlBuffer::new();
-                let fragment = table_columns_to_json_object(&local_table_name, &as_schema_table)?;
+                let fragment = table_columns_to_json_object(local_table_name, &as_schema_table)?;
                 buffer.push_str("INSERT INTO ps_untyped (type, id, data) SELECT ?, id, ");
                 buffer.push_str(&fragment);
                 buffer.push_str(" FROM ");

--- a/crates/core/src/schema/mod.rs
+++ b/crates/core/src/schema/mod.rs
@@ -92,6 +92,11 @@ fn raw_table_migration(
     args: &[*mut sqlite::value],
 ) -> Result<(), PowerSyncError> {
     let db = context.db_handle();
+    if db.get_autocommit() {
+        return Err(PowerSyncError::argument_error(
+            "powersync_raw_table_migrate must be called within a transaction",
+        ));
+    }
     let context = unsafe { DatabaseState::from_context(&context) };
     let action = RawTableMigration::from_args(args)?;
 

--- a/crates/core/src/sync/mod.rs
+++ b/crates/core/src/sync/mod.rs
@@ -16,6 +16,7 @@ mod sync_status;
 
 pub use bucket_priority::BucketPriority;
 pub use checksum::Checksum;
+pub use sync_local::RawTableWithCachedStatements;
 
 use crate::state::DatabaseState;
 pub use streaming_sync::SyncClient;

--- a/crates/core/src/sync/sync_local.rs
+++ b/crates/core/src/sync/sync_local.rs
@@ -433,13 +433,21 @@ struct ParsedSchemaTable<'a> {
     raw: Option<RawTableWithCachedStatements<'a>>,
 }
 
-struct RawTableWithCachedStatements<'a> {
+pub struct RawTableWithCachedStatements<'a> {
     definition: &'a RawTable,
     cached_put: Option<PreparedPendingStatement>,
     cached_delete: Option<PreparedPendingStatement>,
 }
 
 impl<'a> RawTableWithCachedStatements<'a> {
+    pub fn new(definition: &'a RawTable) -> Self {
+        Self {
+            definition,
+            cached_put: None,
+            cached_delete: None,
+        }
+    }
+
     fn prepare_lazily(
         db: *mut sqlite::sqlite3,
         slot: &mut Option<PreparedPendingStatement>,
@@ -454,7 +462,7 @@ impl<'a> RawTableWithCachedStatements<'a> {
         })
     }
 
-    fn put_statement(
+    pub fn put_statement(
         &'_ mut self,
         db: *mut sqlite::sqlite3,
         schema_version: usize,
@@ -494,16 +502,12 @@ impl<'a> ParsedSchemaTable<'a> {
 
     pub fn raw(definition: &'a RawTable) -> Self {
         Self {
-            raw: Some(RawTableWithCachedStatements {
-                definition,
-                cached_put: None,
-                cached_delete: None,
-            }),
+            raw: Some(RawTableWithCachedStatements::new(definition)),
         }
     }
 }
 
-struct PreparedPendingStatement {
+pub struct PreparedPendingStatement {
     stmt: ManagedStmt,
     definition: Rc<PendingStatement>,
 }

--- a/dart/test/error_test.dart
+++ b/dart/test/error_test.dart
@@ -40,6 +40,8 @@ void main() {
           'SELECT powersync_clear(?)', 'powersync_clear', [0]);
       expectErrorOutsideOfTransaction(
           'SELECT powersync_trigger_resync(TRUE)', 'powersync_trigger_resync');
+      expectErrorOutsideOfTransaction('SELECT powersync_raw_table_migrate(?,?)',
+          'powersync_raw_table_migrate', ['create', 'a']);
     });
 
     test('contain inner SQLite descriptions', () {

--- a/dart/test/schema_test.dart
+++ b/dart/test/schema_test.dart
@@ -333,15 +333,7 @@ END''',
         };
       }
 
-      setUp(() => db.execute('SELECT powersync_init();'));
-
-      test('requires a transaction', () {
-        expect(
-          () => db.execute(
-              'SELECT powersync_raw_table_migrate(?, ?)', ['create', syncName]),
-          throwsA(isA<SqliteException>()),
-        );
-      });
+      setUp(() => db.executeInTx('SELECT powersync_init();'));
 
       group('create', () {
         void createUntypedItem(String id, Object? json) {
@@ -355,17 +347,15 @@ END''',
           createUntypedItem('foo', {'hello': 'world'});
           createUntypedItem('bar', {'hello': 'again'});
 
-          db.execute('SELECT powersync_replace_schema(?)', [
+          db.executeInTx('SELECT powersync_replace_schema(?)', [
             json.encode(singleRawTableSchema(
                 {'name': syncName, 'table_name': 'greetings'})),
           ]);
           db.execute(
               'CREATE TABLE greetings (id TEXT PRIMARY KEY, hello TEXT) STRICT;');
 
-          db.execute('BEGIN');
-          db.execute(
+          db.executeInTx(
               'SELECT powersync_raw_table_migrate(?, ?)', ['create', syncName]);
-          db.execute('COMMIT');
           expect(db.select('select * from ps_untyped'), isEmpty);
           expect(db.select('select * from greetings'), [
             {'id': 'foo', 'hello': 'world'},
@@ -377,7 +367,7 @@ END''',
           createUntypedItem('foo', {'hello': 'world'});
           createUntypedItem('bar', {'hello': 'again'});
 
-          db.execute('SELECT powersync_replace_schema(?)', [
+          db.executeInTx('SELECT powersync_replace_schema(?)', [
             json.encode(singleRawTableSchema({
               'name': syncName,
               'put': {
@@ -393,15 +383,26 @@ END''',
           db.execute(
               'CREATE TABLE greetings (id TEXT PRIMARY KEY, hello TEXT) STRICT;');
 
-          db.execute('BEGIN');
-          db.execute(
+          db.executeInTx(
               'SELECT powersync_raw_table_migrate(?, ?)', ['create', syncName]);
-          db.execute('COMMIT');
           expect(db.select('select * from ps_untyped'), isEmpty);
           expect(db.select('select * from greetings'), [
             {'id': 'foo', 'hello': 'world'},
             {'id': 'bar', 'hello': 'again'},
           ]);
+        });
+
+        test('errors when table is not in schema', () {
+          db.executeInTx('SELECT powersync_replace_schema(?)', [
+            json.encode(singleRawTableSchema(
+                {'name': syncName, 'table_name': 'greetings'})),
+          ]);
+
+          expect(
+            () => db.executeInTx('SELECT powersync_raw_table_migrate(?, ?)',
+                ['create', 'unknown_table']),
+            throwsA(isA<SqliteException>()),
+          );
         });
       });
 
@@ -417,28 +418,26 @@ END''',
             'INSERT INTO greetings (id, hello, local) VALUES (?, ?, uuid())',
             ['id_1', 'second'],
           )
-          ..execute('BEGIN')
-          ..execute('SELECT powersync_raw_table_migrate(?, ?)', [
+          ..executeInTx('SELECT powersync_raw_table_migrate(?, ?)', [
             'drop',
             json.encode({
               'name': syncName,
               'table_name': 'greetings',
               'synced_columns': ['hello']
             })
-          ])
-          ..execute('COMMIT');
-
+          ]);
         expect(db.select('select * from ps_untyped'), [
           {'type': 'synced_table', 'id': 'id_0', 'data': '{"hello":"first"}'},
           {'type': 'synced_table', 'id': 'id_1', 'data': '{"hello":"second"}'},
         ]);
+        expect(db.select('select * from greetings'), isEmpty);
       });
 
       test('crud triggers are not invoked during migration', () {
         final tableJson =
             json.encode({'name': syncName, 'table_name': 'greetings'});
 
-        db.execute('SELECT powersync_replace_schema(?)', [
+        db.executeInTx('SELECT powersync_replace_schema(?)', [
           json.encode(singleRawTableSchema(
               {'name': syncName, 'table_name': 'greetings'})),
         ]);

--- a/dart/test/schema_test.dart
+++ b/dart/test/schema_test.dart
@@ -322,6 +322,141 @@ END''',
         test('#$i', () => testCase.testWith(db));
       }
     });
+
+    group('powersync_raw_table_migrate', () {
+      const syncName = 'synced_table';
+
+      Object singleRawTableSchema(Object rawTable) {
+        return {
+          'tables': [],
+          'raw_tables': [rawTable]
+        };
+      }
+
+      setUp(() => db.execute('SELECT powersync_init();'));
+
+      group('create', () {
+        void createUntypedItem(String id, Object? json) {
+          db.execute(
+            'INSERT INTO ps_untyped (type, id, data) VALUES (?, ?, ?)',
+            [syncName, id, jsonEncode(json)],
+          );
+        }
+
+        test('inferred statements', () {
+          createUntypedItem('foo', {'hello': 'world'});
+          createUntypedItem('bar', {'hello': 'again'});
+
+          db.execute('SELECT powersync_replace_schema(?)', [
+            json.encode(singleRawTableSchema(
+                {'name': syncName, 'table_name': 'greetings'})),
+          ]);
+          db.execute(
+              'CREATE TABLE greetings (id TEXT PRIMARY KEY, hello TEXT) STRICT;');
+
+          db.execute(
+              'SELECT powersync_raw_table_migrate(?, ?)', ['create', syncName]);
+          expect(db.select('select * from ps_untyped'), isEmpty);
+          expect(db.select('select * from greetings'), [
+            {'id': 'foo', 'hello': 'world'},
+            {'id': 'bar', 'hello': 'again'},
+          ]);
+        });
+
+        test('custom put statement', () {
+          createUntypedItem('foo', {'hello': 'world'});
+          createUntypedItem('bar', {'hello': 'again'});
+
+          db.execute('SELECT powersync_replace_schema(?)', [
+            json.encode(singleRawTableSchema({
+              'name': syncName,
+              'put': {
+                'sql': 'INSERT INTO greetings (id, hello) VALUES (?, ?)',
+                'params': [
+                  'Id',
+                  {'Column': 'hello'},
+                ],
+              },
+              'delete': {'sql': 'unused', 'params': []}
+            })),
+          ]);
+          db.execute(
+              'CREATE TABLE greetings (id TEXT PRIMARY KEY, hello TEXT) STRICT;');
+
+          db.execute(
+              'SELECT powersync_raw_table_migrate(?, ?)', ['create', syncName]);
+          expect(db.select('select * from ps_untyped'), isEmpty);
+          expect(db.select('select * from greetings'), [
+            {'id': 'foo', 'hello': 'world'},
+            {'id': 'bar', 'hello': 'again'},
+          ]);
+        });
+      });
+
+      test('drop', () {
+        db
+          ..execute(
+              'CREATE TABLE greetings (id TEXT PRIMARY KEY, hello TEXT, local TEXT) STRICT;')
+          ..execute(
+            'INSERT INTO greetings (id, hello, local) VALUES (?, ?, uuid())',
+            ['id_0', 'first'],
+          )
+          ..execute(
+            'INSERT INTO greetings (id, hello, local) VALUES (?, ?, uuid())',
+            ['id_1', 'second'],
+          )
+          ..execute('SELECT powersync_raw_table_migrate(?, ?)', [
+            'drop',
+            json.encode({
+              'name': syncName,
+              'table_name': 'greetings',
+              'synced_columns': ['hello']
+            })
+          ]);
+
+        expect(db.select('select * from ps_untyped'), [
+          {'type': 'synced_table', 'id': 'id_0', 'data': '{"hello":"first"}'},
+          {'type': 'synced_table', 'id': 'id_1', 'data': '{"hello":"second"}'},
+        ]);
+      });
+
+      test('crud triggers are not invoked during migration', () {
+        final tableJson =
+            json.encode({'name': syncName, 'table_name': 'greetings'});
+
+        db.execute('SELECT powersync_replace_schema(?)', [
+          json.encode(
+              singleRawTableSchema({'name': syncName, 'table_name': 'greetings'})),
+        ]);
+        db.execute(
+            'CREATE TABLE greetings (id TEXT PRIMARY KEY, hello TEXT) STRICT;');
+
+        db.execute('''
+SELECT
+  powersync_create_raw_table_crud_trigger(?1, 'greetings_insert', 'INSERT'),
+  powersync_create_raw_table_crud_trigger(?1, 'greetings_update', 'UPDATE'),
+  powersync_create_raw_table_crud_trigger(?1, 'greetings_delete', 'DELETE')
+''', [tableJson]);
+
+        db
+          ..execute('INSERT INTO ps_untyped (type, id, data) VALUES (?, ?, ?)',
+              [syncName, 'id_1', json.encode({'hello': 'world'})])
+          ..execute('INSERT INTO ps_untyped (type, id, data) VALUES (?, ?, ?)',
+              [syncName, 'id_2', json.encode({'hello': 'again'})]);
+
+        // create migration: ps_untyped -> raw table; triggers must not fire
+        db.execute(
+            'SELECT powersync_raw_table_migrate(?, ?)', ['create', syncName]);
+        expect(db.select('SELECT * FROM ps_crud'), isEmpty);
+
+        // drop migration: raw table -> ps_untyped; triggers must not fire
+        db.execute('SELECT powersync_raw_table_migrate(?, ?)', [
+          'drop',
+          json.encode({'name': syncName, 'table_name': 'greetings'}),
+        ]);
+        expect(db.select('SELECT * FROM ps_crud'), isEmpty);
+      });
+    });
   });
 }
 

--- a/dart/test/schema_test.dart
+++ b/dart/test/schema_test.dart
@@ -335,6 +335,14 @@ END''',
 
       setUp(() => db.execute('SELECT powersync_init();'));
 
+      test('requires a transaction', () {
+        expect(
+          () => db.execute(
+              'SELECT powersync_raw_table_migrate(?, ?)', ['create', syncName]),
+          throwsA(isA<SqliteException>()),
+        );
+      });
+
       group('create', () {
         void createUntypedItem(String id, Object? json) {
           db.execute(
@@ -354,8 +362,10 @@ END''',
           db.execute(
               'CREATE TABLE greetings (id TEXT PRIMARY KEY, hello TEXT) STRICT;');
 
+          db.execute('BEGIN');
           db.execute(
               'SELECT powersync_raw_table_migrate(?, ?)', ['create', syncName]);
+          db.execute('COMMIT');
           expect(db.select('select * from ps_untyped'), isEmpty);
           expect(db.select('select * from greetings'), [
             {'id': 'foo', 'hello': 'world'},
@@ -383,8 +393,10 @@ END''',
           db.execute(
               'CREATE TABLE greetings (id TEXT PRIMARY KEY, hello TEXT) STRICT;');
 
+          db.execute('BEGIN');
           db.execute(
               'SELECT powersync_raw_table_migrate(?, ?)', ['create', syncName]);
+          db.execute('COMMIT');
           expect(db.select('select * from ps_untyped'), isEmpty);
           expect(db.select('select * from greetings'), [
             {'id': 'foo', 'hello': 'world'},
@@ -405,6 +417,7 @@ END''',
             'INSERT INTO greetings (id, hello, local) VALUES (?, ?, uuid())',
             ['id_1', 'second'],
           )
+          ..execute('BEGIN')
           ..execute('SELECT powersync_raw_table_migrate(?, ?)', [
             'drop',
             json.encode({
@@ -412,7 +425,8 @@ END''',
               'table_name': 'greetings',
               'synced_columns': ['hello']
             })
-          ]);
+          ])
+          ..execute('COMMIT');
 
         expect(db.select('select * from ps_untyped'), [
           {'type': 'synced_table', 'id': 'id_0', 'data': '{"hello":"first"}'},
@@ -425,8 +439,8 @@ END''',
             json.encode({'name': syncName, 'table_name': 'greetings'});
 
         db.execute('SELECT powersync_replace_schema(?)', [
-          json.encode(
-              singleRawTableSchema({'name': syncName, 'table_name': 'greetings'})),
+          json.encode(singleRawTableSchema(
+              {'name': syncName, 'table_name': 'greetings'})),
         ]);
         db.execute(
             'CREATE TABLE greetings (id TEXT PRIMARY KEY, hello TEXT) STRICT;');
@@ -439,12 +453,21 @@ SELECT
 ''', [tableJson]);
 
         db
-          ..execute('INSERT INTO ps_untyped (type, id, data) VALUES (?, ?, ?)',
-              [syncName, 'id_1', json.encode({'hello': 'world'})])
-          ..execute('INSERT INTO ps_untyped (type, id, data) VALUES (?, ?, ?)',
-              [syncName, 'id_2', json.encode({'hello': 'again'})]);
+          ..execute(
+              'INSERT INTO ps_untyped (type, id, data) VALUES (?, ?, ?)', [
+            syncName,
+            'id_1',
+            json.encode({'hello': 'world'})
+          ])
+          ..execute(
+              'INSERT INTO ps_untyped (type, id, data) VALUES (?, ?, ?)', [
+            syncName,
+            'id_2',
+            json.encode({'hello': 'again'})
+          ]);
 
         // create migration: ps_untyped -> raw table; triggers must not fire
+        db.execute('BEGIN');
         db.execute(
             'SELECT powersync_raw_table_migrate(?, ?)', ['create', syncName]);
         expect(db.select('SELECT * FROM ps_crud'), isEmpty);
@@ -454,6 +477,7 @@ SELECT
           'drop',
           json.encode({'name': syncName, 'table_name': 'greetings'}),
         ]);
+        db.execute('COMMIT');
         expect(db.select('SELECT * FROM ps_crud'), isEmpty);
       });
     });


### PR DESCRIPTION
With the `_rest` column pattern and `powersync_trigger_resync`, we have pretty decent tools integrating PowerSync into migrations altering existing tables.

However, steps to create and drop raw tables could still be simplified a bit:

1. To add raw tables, we currently suggest a [manual copy](https://docs.powersync.com/client-sdks/advanced/raw-tables#adding-raw-tables-as-a-new-table) from `ps_untyped` into the raw table. We forgot to mention that moved rows should also be removed from `ps_untyped` afterwards (https://github.com/powersync-ja/powersync-kotlin/issues/355).
2. For symmetry, one should also move rows back into `ps_untyped` before dropping raw tables. We have no documentation on this at all.

Both steps can be automated fairly easily: For 1, we can use the exact same logic we use in a `sync_local` step to parse the oplog JSON structure from `ps_untyped` through the (inferred or explicit) `put` statement, which copies it into the raw table.
For 2, we can use the existing logic we have to create crud triggers to JSON-ify table contents and write them back into `ps_untyped`.

### Can't we do this implicitly?

[Initially](https://discord.com/channels/1138230179878154300/1504213613009834145/1511830197329199121), I thought we could this in `powersync_init()` / `powersync_update_schema()`, just like we auto-migrate views:

1. We could detect a new raw table in the schema and automatically copy data over.
2. ... and that's where it stops being a good idea, because we can't detect deleted raw tables missing from the schema.

Even 1 breaks in practice because depending on the SDK, users might first call `powersync_init` with the raw table already in the schema before using `execute()` APIs in SDKs to actually create the raw table.

So, this PR adds an explicit function for this, `powersync_raw_table_migrate`. It's supposed to be called like this:

- For new raw tables, after the table has been created and added to the app's schema. Invoke it with `powersync_raw_table_migrate('create', 'name_of_raw_table_in_sync_streams')` to move data from `ps_untyped`.
- For dropped raw tables, before the table gets dropped in a migration. The table would not be part of the app's schema at this point, so it takes a JSON description of the table (necessary to describe local-only columns, which should not be moved to `ps_untyped`).

_AI use disclaimer_: Parts of the implementation and most tests were generated with Claude.