### PR TITLE
Remove RNQS from release checklist template

### DIFF
--- a/.github/actions/xcframework/action.yml
+++ b/.github/actions/xcframework/action.yml
@@ -24,8 +24,7 @@ runs:
     - name: Set up XCode
       uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
       with:
-        # TODO: Update to latest-stable once GH installs iOS 26 simulators
-        xcode-version: '^16.4.0'
+        xcode-version: latest-stable
     
     - name: List simulators
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,14 +311,13 @@ jobs:
             * [ ] Cocoapod released
 
             SQLite + powersync bundles:
-            * [ ] react-native-quick-sqlite: 
             * [ ] wa-sqlite build: 
             * [ ] sql.js dev adapter: 
 
             User-facing SDK updates:
             * [ ] powersync.dart (see instructions in [this file](https://github.com/powersync-ja/powersync.dart/blob/main/packages/powersync_core/lib/src/database/core_version.dart)):
-            * [ ] powersync-js (directly update node, op-sqlite and capacitor packages; upgrade dependencies on rnqs, wa-sqlite and sql-js in packages and demos):
+            * [ ] powersync-js (directly update node, react-native and capacitor packages; upgrade dependencies on wa-sqlite and sql-js in packages and demos):
             * [ ] kotlin (update in `libs.versions.toml`):
             * [ ] swift (update in `Package.swift`):
-            * [ ] native (update in `Cargo.toml``):
+            * [ ] native (update in `Cargo.toml`):
             * [ ] dotnet (update `Tools/Setup/Setup.cs`)


### PR DESCRIPTION
Since op-sqlite as part of `@powersync/react-native` will be the only option going forward, this removes mentions of the RNQS fork and a separate op-sqlite package from the release checklist.