### PR TITLE
Remove `FlushFileSystem` instruction

### DIFF
--- a/crates/core/src/schema/management.rs
+++ b/crates/core/src/schema/management.rs
@@ -37,65 +37,62 @@ fn update_tables(db: *mut sqlite::sqlite3, schema: &Schema) -> Result<(), PowerS
         map
     };
 
-    {
-        // In a block so that all statements are finalized before dropping tables.
-        for table in &schema.tables {
-            if let Some(existing) = existing_tables.remove(&*table.name) {
-                if existing.local_only != table.local_only() {
-                    // Migrating between local-only and synced tables. This works by deleting
-                    // existing and re-creating the table from scratch. We can re-create first and
-                    // delete the old table afterwards because they have a different name
-                    // (local-only tables have a ps_data_local prefix).
+    for table in &schema.tables {
+        if let Some(existing) = existing_tables.remove(&*table.name) {
+            if existing.local_only != table.local_only() {
+                // Migrating between local-only and synced tables. This works by deleting
+                // existing and re-creating the table from scratch. We can re-create first and
+                // delete the old table afterwards because they have a different name
+                // (local-only tables have a ps_data_local prefix).
 
-                    // To delete the old existing table in the end.
-                    existing_tables.insert(&existing.name, existing);
-                } else {
-                    // Compatible table exists already, nothing to do.
-                    continue;
-                }
-            }
-
-            // New table.
-            let quoted_internal_name = SqlBuffer::quote_identifier(&table.internal_name());
-
-            db.exec_safe(&format!(
-                "CREATE TABLE {:}(id TEXT PRIMARY KEY NOT NULL, data TEXT)",
-                quoted_internal_name
-            ))
-            .into_db_result(db)?;
-
-            if !table.local_only() {
-                // MOVE data if any
-                db.exec_text(
-                    &format!(
-                        "INSERT INTO {:}(id, data)
-    SELECT id, data
-    FROM ps_untyped
-    WHERE type = ?",
-                        quoted_internal_name
-                    ),
-                    &table.name,
-                )
-                .into_db_result(db)?;
-
-                // language=SQLite
-                db.exec_text("DELETE FROM ps_untyped WHERE type = ?", &table.name)?;
+                // To delete the old existing table in the end.
+                existing_tables.insert(&existing.name, existing);
+            } else {
+                // Compatible table exists already, nothing to do.
+                continue;
             }
         }
 
-        // Remaining tables need to be dropped. But first, we want to move their contents to
-        // ps_untyped.
-        for remaining in existing_tables.values() {
-            if !remaining.local_only {
-                db.exec_text(
-                    &format!(
-                        "INSERT INTO ps_untyped(type, id, data) SELECT ?, id, data FROM {:}",
-                        SqlBuffer::quote_identifier(&remaining.internal_name)
-                    ),
-                    &remaining.name,
-                )
-                .into_db_result(db)?;
-            }
+        // New table.
+        let quoted_internal_name = SqlBuffer::quote_identifier(&table.internal_name());
+
+        db.exec_safe(&format!(
+            "CREATE TABLE {:}(id TEXT PRIMARY KEY NOT NULL, data TEXT)",
+            quoted_internal_name
+        ))
+        .into_db_result(db)?;
+
+        if !table.local_only() {
+            // MOVE data if any
+            db.exec_text(
+                &format!(
+                    "INSERT INTO {:}(id, data)
+    SELECT id, data
+    FROM ps_untyped
+    WHERE type = ?",
+                    quoted_internal_name
+                ),
+                &table.name,
+            )
+            .into_db_result(db)?;
+
+            // language=SQLite
+            db.exec_text("DELETE FROM ps_untyped WHERE type = ?", &table.name)?;
+        }
+    }
+
+    // Remaining tables need to be dropped. But first, we want to move their contents to
+    // ps_untyped.
+    for remaining in existing_tables.values() {
+        if !remaining.local_only {
+            db.exec_text(
+                &format!(
+                    "INSERT INTO ps_untyped(type, id, data) SELECT ?, id, data FROM {:}",
+                    SqlBuffer::quote_identifier(&remaining.internal_name)
+                ),
+                &remaining.name,
+            )
+            .into_db_result(db)?;
         }
     }
 

--- a/crates/core/src/sync/interface.rs
+++ b/crates/core/src/sync/interface.rs
@@ -139,8 +139,6 @@ pub enum Instruction {
     // object or a literal value
     /// Close the websocket / HTTP stream to the sync service.
     CloseSyncStream(CloseSyncStream),
-    /// Flush the file-system if it's non-durable (only applicable to the Dart SDK).
-    FlushFileSystem {},
     /// Notify that a sync has been completed, prompting client SDKs to clear earlier errors.
     DidCompleteSync {},
 

--- a/crates/core/src/sync/streaming_sync.rs
+++ b/crates/core/src/sync/streaming_sync.rs
@@ -362,7 +362,6 @@ impl StreamingSyncIteration {
                             severity: LogSeverity::DEBUG,
                             line: "Validated and applied checkpoint".into(),
                         });
-                        event.instructions.push(Instruction::FlushFileSystem {});
                         SyncStateMachineTransition::SyncLocalChangesApplied {
                             partial: None,
                             timestamp,

--- a/dart/pubspec.lock
+++ b/dart/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "8d7ff3948166b8ec5da0fbb5962000926b8e02f2ed9b3e51d1738905fbd4c98d"
+      sha256: "9a3386eea899815698dd55995277cf7cb8572ee52b399a6edfb7ae2b50e5fc19"
       url: "https://pub.dev"
     source: hosted
-    version: "93.0.0"
+    version: "105.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: de7148ed2fcec579b19f122c1800933dfa028f6d9fd38a152b04b1516cec120b
+      sha256: "62993bed6eadbe9596c5c20d5c167e7bc563c5fe266657a04ddeb93bdb84f4c9"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.1"
+    version: "14.1.0"
   args:
     dependency: transitive
     description:
@@ -29,10 +29,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: e2eb0491ba5ddb6177742d2da23904574082139b07c1e33b8503b9f46f3e1a37
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.13.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -45,10 +45,10 @@ packages:
     dependency: "direct main"
     description:
       name: bson
-      sha256: f8c80be7a62a88f4add7c48cc83567c36a77532de107224df8328ef71f125045
+      sha256: "6e322cdf827db905ca48b018deed1804934840bce8ff6b3c2f5b2f81f99d8344"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.7"
+    version: "5.0.8"
   cli_config:
     dependency: transitive
     description:
@@ -69,10 +69,10 @@ packages:
     dependency: transitive
     description:
       name: code_assets
-      sha256: "83ccdaa064c980b5596c35dd64a8d3ecc68620174ab9b90b6343b753aa721687"
+      sha256: bf394f466ba9205f1812a0433b392d6af280f155f56651eda7c18cc32ed493b8
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.2.1"
   collection:
     dependency: transitive
     description:
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
+      sha256: "956a3de0725ca232ad353565a8290d3357592bf4250f6f298a185e2d949c5d3d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.15.1"
   crypto:
     dependency: transitive
     description:
@@ -109,10 +109,10 @@ packages:
     dependency: transitive
     description:
       name: decimal
-      sha256: fc706a5618b81e5b367b01dd62621def37abc096f2b46a9bd9068b64c1fa36d0
+      sha256: "4988f89bbbf9de235430300d5ee0e8e87c733a56145dc7d0dd97e6cf90cf809b"
       url: "https://pub.dev"
     source: hosted
-    version: "3.2.4"
+    version: "3.2.5"
   fake_async:
     dependency: "direct dev"
     description:
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      sha256: d07d37192dbf97461359c1518788f203b0c9102cfd2c35a716b823741219542c
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.5"
+    version: "2.2.0"
   file:
     dependency: "direct dev"
     description:
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: hooks
-      sha256: "5d309c86e7ce34cd8e37aa71cb30cb652d3829b900ab145e4d9da564b31d59f7"
+      sha256: "03a564c3704524ee0f7fc56fc621e8796cc2eb8c24d1f1a33b34979815b285c4"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "2.1.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -189,10 +189,10 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   io:
     dependency: transitive
     description:
@@ -213,18 +213,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.20"
   meta:
     dependency: "direct dev"
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mime:
     dependency: transitive
     description:
@@ -237,10 +237,10 @@ packages:
     dependency: transitive
     description:
       name: native_toolchain_c
-      sha256: "8aaead321425bd3f03bd5894aa27c8ea6993eab95531da7e59f5d39c6e5708ec"
+      sha256: a1c26117c48cebe5677b0cf0e33a980a79a7c5577effc86f52e5a0d309cdcb60
       url: "https://pub.dev"
     source: hosted
-    version: "0.18.0"
+    version: "0.19.3"
   node_preamble:
     dependency: transitive
     description:
@@ -253,18 +253,18 @@ packages:
     dependency: transitive
     description:
       name: package_config
-      sha256: f096c55ebb7deb7e384101542bfba8c52696c1b56fca2eb62827989ef2353bbc
+      sha256: ffcf4cf3d6c0b74ac43708d9f56625506e8a68aa935abe9d267a7330f320eb5d
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "3.0.0"
   packages_extensions:
     dependency: transitive
     description:
       name: packages_extensions
-      sha256: "1fb328695a9828c80d275ce1650a2bb5947690070de082dfa1dfac7429378daf"
+      sha256: a2e207f3345fc5cbea60155842e71be1c3059b427a61ed1c5d7c41f5d03264e7
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.1"
+    version: "0.1.2"
   path:
     dependency: "direct dev"
     description:
@@ -285,10 +285,10 @@ packages:
     dependency: transitive
     description:
       name: power_extensions
-      sha256: ad0e8b2420090d996fe8b7fd32cdf02b9b924b6d4fc0fb0b559ff6aa5e24d5b0
+      sha256: ad4e27d040f80bb7e566d96399b6419343d946d7c37912e1bce56c9f2b32e525
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.3"
+    version: "0.2.4"
   pub_semver:
     dependency: transitive
     description:
@@ -305,6 +305,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.3"
+  record_use:
+    dependency: transitive
+    description:
+      name: record_use
+      sha256: af37186ff9ede46fa32f152526c48f46c5b3ad7d3d5a566140cb5df3dc4ed737
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   shelf:
     dependency: transitive
     description:
@@ -357,19 +365,18 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: "254ee5351d6cb365c859e20ee823c3bb479bf4a293c22d17a9f1bf144ce86f7c"
+      sha256: "56a02f1f4cd1a2d96303c0144c93bd6d909eea6bee6bf5a0e0b685edbd4c47ab"
       url: "https://pub.dev"
     source: hosted
-    version: "1.10.1"
+    version: "1.10.2"
   sqlite3:
     dependency: "direct main"
     description:
-      path: sqlite3
-      ref: main
-      resolved-ref: "97268a5b32cf6313dd670e6fa57ae88d38a6564b"
-      url: "https://github.com/simolus3/sqlite3.dart.git"
-    source: git
-    version: "3.3.2"
+      name: sqlite3
+      sha256: c73fd75df1332d76a6257f4823ae4df9c791f522b97e4a60cbcad214de1becf4
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.5.0"
   sqlite3_test:
     dependency: "direct dev"
     description:
@@ -414,26 +421,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
+      sha256: "0d5ba5602ec3baa28c8ce365e1efc5575969c765f45c554a3e167dc7945b9c30"
       url: "https://pub.dev"
     source: hosted
-    version: "1.29.0"
+    version: "1.31.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "475610b2aa23c19687cce2961e44b0cc57cafe220f67c2b80201231b2a07fbe7"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.13"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: a39c204a4fc7a7ccb04a2b985e359fda3cc37e45e0b8ac61c3fb1a05aa832132
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.19"
   test_descriptor:
     dependency: "direct dev"
     description:
@@ -454,18 +461,18 @@ packages:
     dependency: transitive
     description:
       name: uuid
-      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      sha256: "9b129329f58692f6e6578329498a8fe9fbe98f090beb764ffbb8ee2eadd01dcd"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.2"
+    version: "4.6.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "45caa6c5917fa127b5dbcfbd1fa60b14e583afdc08bfc96dda38886ca252eb60"
+      sha256: "0016aef94fc66495ac78af5859181e3f3bf2026bd8eecc72b9565601e19ab360"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.2"
+    version: "15.2.0"
   watcher:
     dependency: transitive
     description:
@@ -515,4 +522,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"

--- a/dart/pubspec.yaml
+++ b/dart/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ^3.4.0
 
 dependencies:
-  sqlite3: ^3.1.4
+  sqlite3: ^3.5.0
   bson: ^5.0.5
 
 dev_dependencies:
@@ -18,15 +18,6 @@ dev_dependencies:
   convert: ^3.1.2
   meta: ^1.16.0
   path: ^1.9.1
-
-dependency_overrides:
-  # TODO: Remove after https://github.com/simolus3/sqlite3.dart/commit/97268a5b32cf6313dd670e6fa57ae88d38a6564b
-  # gets released.
-  sqlite3:
-    git:
-      url: https://github.com/simolus3/sqlite3.dart.git
-      path: sqlite3
-      ref: main
 
 # See https://pub.dev/documentation/sqlite3/latest/topics/hook-topic.html
 hooks:

--- a/dart/test/goldens/simple_iteration.json
+++ b/dart/test/goldens/simple_iteration.json
@@ -136,9 +136,6 @@
         }
       },
       {
-        "FlushFileSystem": {}
-      },
-      {
         "DidCompleteSync": {}
       },
       {

--- a/dart/test/utils/tracking_vfs.dart
+++ b/dart/test/utils/tracking_vfs.dart
@@ -53,7 +53,7 @@ final class TrackingFileSystem extends BaseVirtualFileSystem {
   }
 }
 
-class TrackingFile implements VirtualFileSystemFile {
+class TrackingFile implements VirtualFileSystemFileV1 {
   final TrackingFileSystem vfs;
   final VirtualFileSystemFile parentFile;
   final bool deleteOnClose;
@@ -118,4 +118,12 @@ class TrackingFile implements VirtualFileSystemFile {
 
   @override
   int get xDeviceCharacteristics => parentFile.xDeviceCharacteristics;
+
+  @override
+  int get xSectorSize => 4096;
+
+  @override
+  int xFileControl(SqliteFileControl op, int ptr) {
+    return SqlError.SQLITE_NOTFOUND;
+  }
 }

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -46,8 +46,6 @@ type Instruction = { LogLine: LogLine }
    | { FetchCredentials: FetchCredentials }
    // Close a connection previously started after EstablishSyncStream
    | { CloseSyncStream: { hide_disconnect: boolean } }
-   // For the Dart web client, flush the (otherwise non-durable) file system.
-   | { FlushFileSystem: {} }
    // Notify clients that a checkpoint was completed. Clients can clear the
    // download error state in response to this.
    | { DidCompleteSync: {} }


### PR DESCRIPTION
The `FlushFileSystem` instruction was introduced for the Dart SDK, which used a non-durable IndexedDB-based filesystem on the web that we wanted to flush explicitly after `sync_local` changes. Subsequent optimizations allowed flushing the file system on every write, meaning that this instruction is no longer useful and we can stop emitting it.

As a general maintance item, this also updates Dart dependencies and removes a dependency override. It also removes a superfluous block in schema management code, since we no longer manage statements explicitly there's nothing to drop in there.