### PR TITLE
Prepare 0.5.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powersync_core"
-version = "0.4.14"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "const_format",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.4.14"
+version = "0.5.0"
 dependencies = [
  "powersync_core",
  "powersync_sqlite_nostd",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.4.14"
+version = "0.5.0"
 dependencies = [
  "cc",
  "powersync_core",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite_nostd"
-version = "0.4.14"
+version = "0.5.0"
 dependencies = [
  "bindgen",
  "num-derive 0.4.2",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_static"
-version = "0.4.14"
+version = "0.5.0"
 dependencies = [
  "powersync_core",
  "powersync_sqlite_nostd",
@@ -615,7 +615,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sqlite3"
-version = "0.4.14"
+version = "0.5.0"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 inherits = "wasm"
 
 [workspace.package]
-version = "0.4.14"
+version = "0.5.0"
 edition = "2024"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.powersync"
-version = "0.4.14"
+version = "0.5.0"
 description = "PowerSync Core SQLite Extension"
 
 val localRepo = uri("build/repository/")

--- a/android/src/prefab/prefab.json
+++ b/android/src/prefab/prefab.json
@@ -2,5 +2,5 @@
   "name": "powersync_sqlite_core",
   "schema_version": 2,
   "dependencies": [],
-  "version": "0.4.14"
+  "version": "0.5.0"
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,7 +16,7 @@ name = "powersync_core"
 crate-type = ["rlib"]
 
 [dependencies]
-powersync_sqlite_nostd = { version = "=0.4.14", path = "../sqlite_nostd" }
+powersync_sqlite_nostd = { version = "=0.5.0", path = "../sqlite_nostd" }
 bytes = { version = "1.4", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 num-derive = "0.3"

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.4.14'
+  s.version          = '0.5.0'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -29,7 +29,7 @@ TARGETS=(
   aarch64-apple-tvos-sim
   x86_64-apple-tvos
 )
-VERSION=0.4.14
+VERSION=0.5.0
 
 function generatePlist() {
   min_os_version=0


### PR DESCRIPTION
# PowerSync SQLite Core 0.5.0

These release notes cover changes since `v0.4.14`.

Note: This summary was generated by Codex GPT5.6 Sol. The details were manually verified. 

> [!IMPORTANT]
> **This release contains breaking changes.** SDK integrations must provide explicit transactions,
> consume timestamps as Unix microseconds, remove legacy sync interfaces, and upgrade every process
> sharing a migrated database together. Rust consumers must also use Rust 1.96.0 or newer.

## Highlights


- Add checkpoint requests for protecting local writes and implementing explicit “wait until synced”
behavior in [#198](https://github.com/powersync-ja/powersync-sqlite-core/pull/198)
- Require SDK-managed transactions for PowerSync operations (breaking) in
[#191](https://github.com/powersync-ja/powersync-sqlite-core/pull/191)
- Use microsecond precision for sync timestamps (breaking) in
[#183](https://github.com/powersync-ja/powersync-sqlite-core/pull/183)
- Remove the legacy `powersync_operations` virtual table and sync helpers (breaking) in
[#182](https://github.com/powersync-ja/powersync-sqlite-core/pull/182)
- Remove the `FlushFileSystem` sync instruction (breaking) in
[#202](https://github.com/powersync-ja/powersync-sqlite-core/pull/202)
- Update the minimum supported Rust version to 1.96.0 (breaking) in
[#184](https://github.com/powersync-ja/powersync-sqlite-core/pull/184)

## Checkpoint Requests

Core now supports the checkpoint-request flow used to protect local writes until the service has
observed them and to let SDKs wait for a specific checkpoint to be applied.

- Added `checkpoint_mode: "requests"` to the `powersync_control('start', ...)` payload.
- `EstablishSyncStream` can now include a `checkpoint_request` containing a client ID and initial
  request ID.
- Added the following `powersync_control` commands:
  - `seed_checkpoint_request_id`
  - `next_checkpoint_request_id`
  - `current_checkpoint_request_id`
  - `target_checkpoint_request_id`
- `DidCompleteSync` and sync-status updates can report the applied checkpoint-request ID.
- Added persistent checkpoint-request state in `ps_kv`.
- Added schema migration version 14. This migrates legacy `$local.target_op` state and removes the
  synthetic `$local` bucket row.
- Improved handling of pending checkpoints while local CRUD uploads are outstanding.

See [`docs/write-checkpoint-requests.md`](docs/write-checkpoint-requests.md) and
[`docs/historic-write-checkpoints.md`](docs/historic-write-checkpoints.md) for the full integration
and migration details.

## Breaking and Integration Changes

### 1. Transactions must be managed by the SDK

Core no longer creates transactions automatically around PowerSync operations. SDKs must call
`powersync_control`, `powersync_init`, `powersync_clear`, `powersync_trigger_resync`, and migration
helpers from within an explicit transaction. Calls made outside a transaction now fail instead of
silently creating and committing one.

This avoids implicit commits and gives SDKs control over transaction boundaries and rollback
behavior.

**Required action:** Wrap every call to these functions in an SDK-managed transaction and explicitly
commit or roll it back.

### 2. Timestamp representation changed

Sync timestamps are now Unix timestamps in **microseconds**, not seconds. This affects serialized
sync-status values such as `last_synced_at`, as well as persisted subscription `expires_at` and
`last_synced_at` values.

Schema migration 13 converts existing timestamp data to microseconds.

**Required action:** Update SDK timestamp parsing and conversion logic to interpret these values as
Unix microseconds.

### 3. Legacy sync helpers removed

- Removed the `powersync_operations` virtual table and its legacy operations.
- Removed the legacy `powersync_validate_checkpoint` SQL function.
- Removed legacy sync-client implementation and test coverage.
- Replaced the old operations virtual-table close hook with the internal
  `powersync_internal_close` mechanism.

SDKs using these legacy interfaces must migrate to `powersync_control`.

### 4. Migrated databases are incompatible with older SDKs

Schema migration 14 replaces legacy `$local.target_op` bookkeeping with
`ps_kv.target_checkpoint_request_id`. After migration, older SDKs intentionally fail loudly when
opening the same database instead of silently maintaining state that 0.5.0 no longer reads. This is
particularly relevant to multi-process deployments: all processes sharing a database should be
upgraded together.

The down migration restores the legacy state when migrating to an older schema version.

**Required action:** Upgrade all SDK processes that share a database at the same time. Do not run
0.5.0 and an older SDK concurrently against a database migrated to schema version 14.

### 5. Removed `FlushFileSystem`

Core no longer emits the Dart-specific `FlushFileSystem` sync instruction after applying a
checkpoint. SDKs should not expect or handle this instruction.

**Required action:** Remove any dependency on receiving this instruction after a checkpoint.

### 6. Rust toolchain and API requirements changed

- The minimum supported Rust version is now 1.96.0.
- `powersync_sqlite_nostd::Connection::exec` now accepts `&CStr` and is no longer an unsafe method
  accepting a raw `*const c_char`.

**Required action:** Upgrade Rust build environments and adjust direct callers of
`Connection::exec`.

## Other Runtime Changes

- Improved sync-state, bucket-deletion, schema-management, and local-apply logic.
- Removed the SQLite dependency override from Cargo configuration.
- Fixed static-analysis warnings.

## Build, Test, and CI

- Updated the Rust toolchain and minimum supported Rust version to 1.96.0.
- Replaced the Valgrind job with sanitizer-based Linux testing.
- Added consolidated Dart test runners.
- Adopted Zizmor checks and hardened GitHub Actions workflows.
- Updated GitHub Actions dependencies, including checkout, cache, download-artifact, and Zizmor.
- Simplified release workflow artifact handling.
- Removed RNQS from the release checklist template.
