### PR TITLE
Use different soname for Dart SDK Android build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -59,7 +59,6 @@ rustflags = [
     "-C", "link-arg=-miphonesimulator-version-min=11.0",
 ]
 
-
 [target.x86_64-apple-darwin]
 rustflags = [
     "-C", "link-arg=-mmacosx-version-min=10.13",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -70,30 +70,6 @@ rustflags = [
     "-C", "link-arg=-mmacosx-version-min=10.13",
 ]
 
-
-# For Android, it is important to set the soname.
-# Otherwise, the linker hardcodes the path in the lib,
-# which breaks loading.
-[target.aarch64-linux-android]
-rustflags = [
-    "-C", "link-arg=-Wl,-soname,libpowersync.so",
-]
-
-[target.armv7-linux-androideabi]
-rustflags = [
-    "-C", "link-arg=-Wl,-soname,libpowersync.so",
-]
-
-[target.x86_64-linux-android]
-rustflags = [
-    "-C", "link-arg=-Wl,-soname,libpowersync.so",
-]
-
-[target.i686-linux-android]
-rustflags = [
-    "-C", "link-arg=-Wl,-soname,libpowersync.so",
-]
-
 [target.aarch64-apple-watchos]
 rustflags = [
     "-C", "link-arg=-mwatchos-version-min=9.0",

--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -66,7 +66,6 @@ runs:
 
     - name: Build individual libraries for Dart SDK
       shell: bash
-      if: ${{ inputs.sign-publication == '0' }}
       run: |
         cd android
         ./gradlew buildRustStandalone

--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -64,13 +64,20 @@ runs:
         path: android/build/distributions/powersync_android.zip
         if-no-files-found: error
 
+    - name: Build individual libraries for Dart SDK
+      shell: bash
+      if: ${{ inputs.sign-publication == '0' }}
+      run: |
+        cd android
+        ./gradlew buildRustStandalone
+
     - name: Copy individual libraries
       shell: bash
       run: |
-        cp target/aarch64-linux-android/release/libpowersync.so libpowersync_aarch64.android.so
-        cp target/armv7-linux-androideabi/release/libpowersync.so libpowersync_armv7.android.so
-        cp target/i686-linux-android/release/libpowersync.so libpowersync_x86.android.so
-        cp target/x86_64-linux-android/release/libpowersync.so libpowersync_x64.android.so
+        cp android/build/standalone/arm64-v8a/libpowersync.so libpowersync_aarch64.android.so
+        cp android/build/standalone/arm64-v8a/libpowersync.so libpowersync_armv7.android.so
+        cp android/build/standalone/arm64-v8a/libpowersync.so libpowersync_x86.android.so
+        cp android/build/standalone/arm64-v8a/libpowersync.so libpowersync_x64.android.so
 
     - name: Upload individual libraries
       uses: actions/upload-artifact@v4

--- a/.github/actions/android/action.yml
+++ b/.github/actions/android/action.yml
@@ -75,9 +75,9 @@ runs:
       shell: bash
       run: |
         cp android/build/standalone/arm64-v8a/libpowersync.so libpowersync_aarch64.android.so
-        cp android/build/standalone/arm64-v8a/libpowersync.so libpowersync_armv7.android.so
-        cp android/build/standalone/arm64-v8a/libpowersync.so libpowersync_x86.android.so
-        cp android/build/standalone/arm64-v8a/libpowersync.so libpowersync_x64.android.so
+        cp android/build/standalone/armeabi-v7a/libpowersync.so libpowersync_armv7.android.so
+        cp android/build/standalone/x86/libpowersync.so libpowersync_x86.android.so
+        cp android/build/standalone/x86_64/libpowersync.so libpowersync_x64.android.so
 
     - name: Upload individual libraries
       uses: actions/upload-artifact@v4

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -53,7 +53,7 @@ fun ndkPath(): String {
     error("Expected an NDK 28 or later installation in $ndks")
 }
 
-fun Exec.rustCompilation(project: String, output: String? = null) {
+fun Exec.rustCompilation(soname: String, output: String? = null) {
     group = "build"
     environment("ANDROID_NDK_HOME", ndkPath())
 
@@ -82,17 +82,25 @@ fun Exec.rustCompilation(project: String, output: String? = null) {
             "--release",
             "-Zbuild-std",
             "-p",
-            project,
+            "powersync_loadable",
             "--features",
             "nightly"
         )
     }
 
+    // It's important to set an soname. Otherwise, the linker hardcodes the path in the
+    // lib, which breaks loading.
+    environment["RUSTFLAGS"] = "-C link-arg=-Wl,-soname,$soname"
+
     commandLine(args)
 }
 
-val buildRust = tasks.register<Exec>("buildRust") {
-    rustCompilation("powersync_loadable", "./android/build/intermediates/jniLibs")
+val buildRust by tasks.registering(Exec::class) {
+    rustCompilation("libpowersync.so", "./android/build/intermediates/jniLibs")
+}
+
+val buildRustStandalone by tasks.registering(Exec::class) {
+    rustCompilation("libpowersync_core.so", "./android/build/standalone")
 }
 
 val prefabAar = tasks.register<Zip>("prefabAar") {

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -88,9 +88,9 @@ fun Exec.rustCompilation(soname: String, output: String? = null) {
         )
     }
 
-    // It's important to set an soname. Otherwise, the linker hardcodes the path in the
+    // It's important to set the soname. Otherwise, the linker hardcodes the path in the
     // lib, which breaks loading.
-    environment["RUSTFLAGS"] = "-C link-arg=-Wl,-soname,$soname"
+    environment("RUSTFLAGS", "-C link-arg=-Wl,-soname,$soname")
 
     commandLine(args)
 }


### PR DESCRIPTION
On Android, the core extension is distributed in two ways:

1. As an Android library bundle published to Maven Central (used by the Kotlin and React Native SDKs).
2. As standalone `.so` files attached to GitHub releases (used by the Dart and Dotnet SDKs).

Through peculiar but not entirely unreasonable setups, it's possible to end up with both in the same app. https://github.com/powersync-ja/powersync.dart/issues/442 is an example of this: One database is managed by the PowerSync Dart SDK, another one by the Kotlin SDK. In this setup, two copies of SQLite and the core extension are included in the app. As long as they never touch the same database file, this should be fine. However, because the two builds have the same `soname` entry, the Android loader considers them equal and won't load them both. This causes `sqlite3_powersync_init` to be called twice with different `sqlite3_api_routines` pointers, which quickly leads to crashes as we try to use database pointers from one SQLite copy with function pointers from the other.

To fix this, this gives the distributions unique names: Files in the Android library keep their `libpowersync.so` name, while standalone files are named `libpowersync_core.so`, the name used by the Dart build hook.

I have verified the following with assets attached to CI runs:

- Running `patchelf --print-soname` on `libpowersync.$arch.android.so` files prints `libpowersync_core.so`.
- Running `patchelf --print-soname` on JNI files in the `aar` prints `libpowersync.so`, same as before.
- Changing the Dart SDK to use the updated files allows running it along with the Kotlin library in the same process (tested with [this repro](https://github.com/xvrh/powersync-soname-repro), which would crash before).