### PR TITLE
chore: fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,6 +125,8 @@ jobs:
     name: Publish iOS
     needs: [ draft_release, libs_xcframework ]
     runs-on: macos-latest
+    permissions:
+      contents: write # Needed to upload the XCFramework to the draft release.
     steps:
       - uses: actions/checkout@v7
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powersync_core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bytes",
  "const_format",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "powersync_core",
  "powersync_sqlite_nostd",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "cc",
  "powersync_core",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite_nostd"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bindgen",
  "num-derive 0.4.2",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_static"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "powersync_core",
  "powersync_sqlite_nostd",
@@ -615,7 +615,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sqlite3"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 inherits = "wasm"
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.powersync"
-version = "0.5.0"
+version = "0.5.1"
 description = "PowerSync Core SQLite Extension"
 
 val localRepo = uri("build/repository/")

--- a/android/src/prefab/prefab.json
+++ b/android/src/prefab/prefab.json
@@ -2,5 +2,5 @@
   "name": "powersync_sqlite_core",
   "schema_version": 2,
   "dependencies": [],
-  "version": "0.5.0"
+  "version": "0.5.1"
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,7 +16,7 @@ name = "powersync_core"
 crate-type = ["rlib"]
 
 [dependencies]
-powersync_sqlite_nostd = { version = "=0.5.0", path = "../sqlite_nostd" }
+powersync_sqlite_nostd = { version = "=0.5.1", path = "../sqlite_nostd" }
 bytes = { version = "1.4", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 num-derive = "0.3"

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.5.0'
+  s.version          = '0.5.1'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -29,7 +29,7 @@ TARGETS=(
   aarch64-apple-tvos-sim
   x86_64-apple-tvos
 )
-VERSION=0.5.0
+VERSION=0.5.1
 
 function generatePlist() {
   min_os_version=0


### PR DESCRIPTION
The iOS publish job is currently [failing](https://github.com/powersync-ja/powersync-sqlite-core/actions/runs/30261574160/job/89967101038) with: 

```
release not found
```

When attempting to upload the XCFramework to the draft Github release.

It seems like the iOS workflow does not have the `write` permission configured. Which is needed to upload files to a release.

AI usage: The fix was found by Codex GPT 5.6

The `v0.5.0` draft release currently does not include iOS frameworks. After merging this, we could delete the release and tag and re-push a new tag. 