### PR TITLE
Prepare 0.5.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "powersync_core"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bytes",
  "const_format",
@@ -430,7 +430,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_loadable"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "powersync_core",
  "powersync_sqlite_nostd",
@@ -438,7 +438,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "cc",
  "powersync_core",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_sqlite_nostd"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bindgen",
  "num-derive 0.4.2",
@@ -456,7 +456,7 @@ dependencies = [
 
 [[package]]
 name = "powersync_static"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "powersync_core",
  "powersync_sqlite_nostd",
@@ -615,7 +615,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "sqlite3"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 inherits = "wasm"
 
 [workspace.package]
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 authors = ["JourneyApps"]
 keywords = ["sqlite", "powersync"]

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
 }
 
 group = "com.powersync"
-version = "0.5.1"
+version = "0.5.2"
 description = "PowerSync Core SQLite Extension"
 
 val localRepo = uri("build/repository/")

--- a/android/src/prefab/prefab.json
+++ b/android/src/prefab/prefab.json
@@ -2,5 +2,5 @@
   "name": "powersync_sqlite_core",
   "schema_version": 2,
   "dependencies": [],
-  "version": "0.5.1"
+  "version": "0.5.2"
 }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,7 +16,7 @@ name = "powersync_core"
 crate-type = ["rlib"]
 
 [dependencies]
-powersync_sqlite_nostd = { version = "=0.5.1", path = "../sqlite_nostd" }
+powersync_sqlite_nostd = { version = "=0.5.2", path = "../sqlite_nostd" }
 bytes = { version = "1.4", default-features = false }
 num-traits = { version = "0.2.15", default-features = false }
 num-derive = "0.3"

--- a/powersync-sqlite-core.podspec
+++ b/powersync-sqlite-core.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'powersync-sqlite-core'
-  s.version          = '0.5.1'
+  s.version          = '0.5.2'
   s.summary          = 'PowerSync SQLite Extension'
   s.description      = <<-DESC
 PowerSync extension for SQLite.

--- a/tool/build_xcframework.sh
+++ b/tool/build_xcframework.sh
@@ -29,7 +29,7 @@ TARGETS=(
   aarch64-apple-tvos-sim
   x86_64-apple-tvos
 )
-VERSION=0.5.1
+VERSION=0.5.2
 
 function generatePlist() {
   min_os_version=0


### PR DESCRIPTION
This updates the version number to 0.5.2 and prepares a release.

The only change since the 0.5.1 release is https://github.com/powersync-ja/powersync-sqlite-core/pull/207. I have manually verified the fix by building `libpowersync-wasm.a` locally, pulling that into a local `@journeyapps/wa-sqlite` build and adding a dependency override in the JS SDK to the local packe. This fixes tests in `@powersync/web`, which are broken in 0.5.1 due to leaked prepared statements.